### PR TITLE
Fix dark-mode by scanning tsx in Tailwind config

### DIFF
--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./pages/**/*.{js,jsx}', './components/**/*.{js,jsx}'],
+  content: [
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+  ],
   darkMode: 'class',
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- scan `pages` and `components` TS/TSX files in Tailwind config

## Testing
- `pnpm -v` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687b6212bf808332b117cde7cca4ad01