### PR TITLE
chore: ignore TypeScript *.tsbuildinfo artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ Thumbs.db
 # ─────────────────────────────────────────────────────────────────────────────
 *.seed
 *.pid
+# TypeScript build info
+*.tsbuildinfo


### PR DESCRIPTION
Summary
	•	Ignore TypeScript build artifacts across the repo: *.tsbuildinfo.

Why
	•	These files are compiler caches, machine-local, and cause noisy diffs & branch switching issues.

Changes
	•	Add *.tsbuildinfo to the root .gitignore.
	•	Untrack any previously committed tsconfig*.tsbuildinfo files.

How to test
	•	Run pnpm -w typecheck twice; confirm no git status changes.
	•	git ls-files '*.tsbuildinfo' returns nothing.

Risk/Rollback
	•	Low. If needed, revert the .gitignore entry.

Acceptance
	•	No *.tsbuildinfo shows up in git status or CI diffs.
	•	Branch switching no longer blocked by these files.