### PR TITLE
feat(market): standardize storage key to hedgr.market and make market selection reactive

### DIFF
--- a/apps/frontend/__tests__/fx-rate-context.test.tsx
+++ b/apps/frontend/__tests__/fx-rate-context.test.tsx
@@ -12,6 +12,7 @@ global.fetch = vi.fn();
 vi.mock('../config/market', () => ({
   resolveMarket: () => 'ZM',
   resolveLocalCurrencyCode: () => 'ZMW',
+  useSelectedMarket: () => 'ZM',
 }));
 
 // Mock getFxMode

--- a/apps/frontend/components/BalanceWithLocalEstimate.tsx
+++ b/apps/frontend/components/BalanceWithLocalEstimate.tsx
@@ -49,8 +49,8 @@ export function BalanceWithLocalEstimate({
   // Check if FX rate is available and valid
   const hasFxRate = isFxRateAvailable(fxRate);
   
-  // Calculate local currency amount
-  const localAmount = hasFxRate ? usdAmount * fxRate.rate : 0;
+  // Calculate local currency amount (rate is guaranteed non-null when hasFxRate is true)
+  const localAmount = hasFxRate && fxRate.rate !== null ? usdAmount * fxRate.rate : 0;
   
   // Format USD amount
   const formattedUsd = `$${usdAmount.toFixed(2)}`;

--- a/apps/frontend/components/TrustDisclosureBanner.tsx
+++ b/apps/frontend/components/TrustDisclosureBanner.tsx
@@ -6,7 +6,7 @@ import { getDefiMode } from '../lib/defi/mode';
 import { getFxMode } from '../lib/fx';
 import { 
   isMarketSwitcherEnabled, 
-  resolveMarket, 
+  useSelectedMarket,
   setMarket, 
   MARKET_CONFIG,
   type MarketCode 
@@ -70,16 +70,12 @@ export function TrustDisclosureBanner({
 
   // Market switcher state (only if enabled)
   const marketSwitcherEnabled = isMarketSwitcherEnabled();
-  const currentMarket = marketSwitcherEnabled ? resolveMarket() : null;
+  const selectedMarket = useSelectedMarket();
+  const currentMarket = marketSwitcherEnabled ? selectedMarket : null;
 
   const handleMarketChange = (newMarket: MarketCode) => {
     if (!marketSwitcherEnabled) return;
-    try {
-      setMarket(newMarket);
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to change market:', error);
-    }
+    setMarket(newMarket);
   };
 
   if (variant === 'compact') {

--- a/apps/frontend/config/useSelectedMarket.ts
+++ b/apps/frontend/config/useSelectedMarket.ts
@@ -1,0 +1,63 @@
+'use client';
+
+/**
+ * Client-side React hook for reactive market selection.
+ * 
+ * This module is separated from market.ts to allow server components
+ * to import market config without pulling in client-only React hooks.
+ */
+
+import { useSyncExternalStore } from 'react';
+import { resolveMarket, MARKET_CHANGE_EVENT, type MarketCode } from './market';
+
+/**
+ * Subscribe to market changes (cross-tab via 'storage' event + same-tab via custom event).
+ * SSR-safe: returns noop unsubscribe on server.
+ * 
+ * @param onStoreChange - Function to call when market changes
+ * @returns Unsubscribe function
+ */
+function subscribeMarket(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handler = () => onStoreChange();
+
+  // Listen for cross-tab storage changes
+  window.addEventListener('storage', handler);
+  // Listen for same-tab market changes
+  window.addEventListener(MARKET_CHANGE_EVENT, handler);
+
+  return () => {
+    window.removeEventListener('storage', handler);
+    window.removeEventListener(MARKET_CHANGE_EVENT, handler);
+  };
+}
+
+/**
+ * Get snapshot of current market (for useSyncExternalStore).
+ * Client-side snapshot reads from localStorage.
+ */
+function getMarketSnapshot(): MarketCode {
+  return resolveMarket();
+}
+
+/**
+ * Server snapshot for useSyncExternalStore.
+ * Returns the default market for SSR (never reads localStorage).
+ */
+function getMarketServerSnapshot(): MarketCode {
+  const env = process.env.NEXT_PUBLIC_DEFAULT_MARKET;
+  return (env === 'ZM' || env === 'NG' || env === 'KE') ? env : 'ZM';
+}
+
+/**
+ * React hook for reactive market selection.
+ * Uses useSyncExternalStore for tear-free reads.
+ * 
+ * @returns Current MarketCode, reactively updated on market change
+ */
+export function useSelectedMarket(): MarketCode {
+  return useSyncExternalStore(subscribeMarket, getMarketSnapshot, getMarketServerSnapshot);
+}


### PR DESCRIPTION
## Summary
Standardizes market storage key to `hedgr.market` and implements reactive market selection using `useSyncExternalStore`. Market switching now updates UI + FX immediately in the same tab without requiring navigation or page reload.

## Scope
**In**
- Rename storage key from `hedgr:demo-market` to `hedgr.market` (single SSoT)
- Add `useSelectedMarket()` hook with `useSyncExternalStore` for same-tab reactivity
- Separate client hook into `config/useSelectedMarket.ts` for SSR compatibility
- Update TrustDisclosureBanner to use reactive hook (no page reload)
- Update FxRateContext to react to market changes immediately
- Update tests for new storage key and event dispatch

**Out**
- No changes to market resolution order (localStorage → env → ZM fallback)
- No changes to feature flag behavior (NEXT_PUBLIC_ENABLE_MARKET_SWITCHER)

## Acceptance Criteria (Gherkin)
- [x] Given NEXT_PUBLIC_ENABLE_MARKET_SWITCHER=true, When user switches ZMW → NGN → KES → ZMW, Then banner updates immediately each time
- [x] Given market switcher enabled, When user changes market, Then Dashboard/Deposit/Withdraw update immediately without navigation
- [x] Given user switches back to ZMW, When FX fetch occurs, Then network call shows /api/fx?quote=ZMW

---

## Tests (author attestation)
- [x] Unit tests added/updated where logic changed
- [x] E2E updated/added if user flows or critical paths changed

> 247 unit tests pass, 30 e2e tests pass

---

## Merge Gates (system-enforced)
**Required checks**
- validate (unit, typecheck, lint)
- E2E smoke (@hedgr/frontend)

**Required labels**
- `product:approved` (HedgrOps)
- `qa:approved` (Codex QA)
- one `area:*`
- one `risk:*`

---

## Rollback Strategy
- [x] Single revert commit
- [x] Flag flip back to defaults (`mock` / `fixed`)
- [x] No irreversible data migration

---

## Security & Trust (non-negotiable)
- [x] No secrets introduced or exercised in CI
- [x] Analytics and live networks blocked in tests
- [x] Server-only secrets remain server-only

---

## PR Checklist (prevent CI footguns)

### Routing & Architecture
- [x] No duplicate routes across `pages/*` and `app/*`
- [x] New routes follow the repo's current routing convention

### Flags & Environments
- [x] CI defaults unchanged (`AUTH_MODE=mock`, `FX_MODE=fixed`, `DEFI_MODE=mock`)
- [x] Live providers (Magic, CoinGecko, Aave) are **flag-guarded** and local-only
- [x] No code path can accidentally hit live services in CI/E2E

### Tests & State
- [x] Browser-dependent tests explicitly use `jsdom`
- [x] Zustand persistence tests rely on deterministic storage
- [x] No reliance on real time, real network, or implicit globals

### E2E (Playwright)
- [x] Locators use **roles or `data-testid`**
- [x] No ambiguous `getByText()` in strict mode
- [x] E2E remains hermetic and deterministic

### Build & Determinism
- [x] Local verification run:
  ```bash
  pnpm -w build       # ✅ passed
  pnpm -w test        # ✅ 247 tests passed
  pnpm --filter @hedgr/frontend run e2e:ci  # ✅ 30 passed, 7 skipped
  ```