### PR TITLE
feat(S09-COPILOT-SIGNALS): Deterministic trust-first signal mapping

### DIFF
--- a/apps/frontend/__tests__/copilotSignals.test.ts
+++ b/apps/frontend/__tests__/copilotSignals.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect } from 'vitest';
+import { deriveRecommendation } from '../lib/server/copilotSignals';
+import type {
+  CopilotSignals,
+  MarketSignal,
+  YieldSignal,
+  UserSignal,
+  CopilotRecommendation,
+} from '../lib/server/copilotSignals';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const stableMarket: MarketSignal = {
+  fxVolatilityLevel: 'low',
+  marketStatus: 'normal',
+};
+
+const elevatedMarket: MarketSignal = {
+  fxVolatilityLevel: 'elevated',
+  marketStatus: 'normal',
+};
+
+const highVolatilityMarket: MarketSignal = {
+  fxVolatilityLevel: 'high',
+  marketStatus: 'normal',
+};
+
+const uncertainMarket: MarketSignal = {
+  fxVolatilityLevel: 'low',
+  marketStatus: 'uncertain',
+};
+
+const stableYield: YieldSignal = {
+  yieldAvailability: 'normal',
+  yieldRiskLevel: 'low',
+};
+
+const elevatedYield: YieldSignal = {
+  yieldAvailability: 'normal',
+  yieldRiskLevel: 'elevated',
+};
+
+const uncertainYield: YieldSignal = {
+  yieldAvailability: 'uncertain',
+  yieldRiskLevel: 'low',
+};
+
+const stableUser: UserSignal = {
+  recentDeposit: false,
+  liquiditySensitivity: 'low',
+};
+
+const recentDepositUser: UserSignal = {
+  recentDeposit: true,
+  liquiditySensitivity: 'low',
+};
+
+const highSensitivityUser: UserSignal = {
+  recentDeposit: false,
+  liquiditySensitivity: 'high',
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('copilotSignals', () => {
+  describe('deriveRecommendation', () => {
+    // ────────────────────────────────────────────────────────────────────────
+    // Missing Signals → wait
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('missing signals → wait', () => {
+      it('returns wait when market signal is missing', () => {
+        const signals: CopilotSignals = {
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when yield signal is missing', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when user signal is missing', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when all signals are missing', () => {
+        const signals: CopilotSignals = {};
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when only environment is provided', () => {
+        const signals: CopilotSignals = {
+          environment: { environment: 'prod' },
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Invalid Signal Fields → wait
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('invalid signal fields → wait', () => {
+      it('returns wait when market.fxVolatilityLevel is invalid', () => {
+        const signals: CopilotSignals = {
+          market: { fxVolatilityLevel: 'invalid' as any, marketStatus: 'normal' },
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when market.marketStatus is invalid', () => {
+        const signals: CopilotSignals = {
+          market: { fxVolatilityLevel: 'low', marketStatus: 'invalid' as any },
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when yield.yieldAvailability is invalid', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: { yieldAvailability: 'invalid' as any, yieldRiskLevel: 'low' },
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when yield.yieldRiskLevel is invalid', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: { yieldAvailability: 'normal', yieldRiskLevel: 'invalid' as any },
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when user.recentDeposit is not a boolean', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: { recentDeposit: 'yes' as any, liquiditySensitivity: 'low' },
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when user.liquiditySensitivity is invalid', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: { recentDeposit: false, liquiditySensitivity: 'invalid' as any },
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when market signal fields are undefined', () => {
+        const signals: CopilotSignals = {
+          market: { fxVolatilityLevel: undefined as any, marketStatus: undefined as any },
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Unsafe Conditions → wait
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('unsafe conditions → wait', () => {
+      it('returns wait when fxVolatilityLevel is high', () => {
+        const signals: CopilotSignals = {
+          market: highVolatilityMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when marketStatus is uncertain', () => {
+        const signals: CopilotSignals = {
+          market: uncertainMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when yieldAvailability is uncertain', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: uncertainYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when liquiditySensitivity is high', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: highSensitivityUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when multiple unsafe conditions are present', () => {
+        const signals: CopilotSignals = {
+          market: { fxVolatilityLevel: 'high', marketStatus: 'uncertain' },
+          yield: uncertainYield,
+          user: highSensitivityUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Conflicting Signals → wait
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('conflicting signals → wait', () => {
+      it('returns wait when marketStatus is normal but yieldAvailability is uncertain', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: uncertainYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when market is stable but user has high liquidity sensitivity', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: highSensitivityUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Stable Conditions → proceed
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('stable conditions → proceed', () => {
+      it('returns proceed when all conditions are stable (low sensitivity)', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('returns proceed when all conditions are stable (medium sensitivity)', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: { recentDeposit: false, liquiditySensitivity: 'medium' },
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('returns proceed when all conditions are stable with recent deposit', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: { recentDeposit: true, liquiditySensitivity: 'low' },
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('returns proceed regardless of environment signal', () => {
+        const signals: CopilotSignals = {
+          environment: { environment: 'dev' },
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Cautious Conditions → proceed_cautiously
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('cautious conditions → proceed_cautiously', () => {
+      it('returns proceed_cautiously when elevated volatility + elevated yield risk + recent deposit', () => {
+        const signals: CopilotSignals = {
+          market: elevatedMarket,
+          yield: elevatedYield,
+          user: recentDepositUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed_cautiously');
+      });
+
+      it('returns proceed_cautiously with medium liquidity sensitivity', () => {
+        const signals: CopilotSignals = {
+          market: elevatedMarket,
+          yield: elevatedYield,
+          user: { recentDeposit: true, liquiditySensitivity: 'medium' },
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed_cautiously');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Fallback → wait
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('fallback → wait', () => {
+      it('returns wait when conditions do not match stable or cautious (elevated volatility, no recent deposit)', () => {
+        const signals: CopilotSignals = {
+          market: elevatedMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when elevated volatility but low yield risk', () => {
+        const signals: CopilotSignals = {
+          market: elevatedMarket,
+          yield: stableYield,
+          user: recentDepositUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when elevated yield risk but low volatility', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: elevatedYield,
+          user: recentDepositUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+
+      it('returns wait when reduced yield availability with elevated volatility (no cautious match)', () => {
+        // "reduced" is not unsafe, but elevated volatility + reduced availability
+        // doesn't match cautious (needs elevated yield risk) or stable (needs low volatility)
+        const signals: CopilotSignals = {
+          market: elevatedMarket,
+          yield: { yieldAvailability: 'reduced', yieldRiskLevel: 'low' },
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('wait');
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Determinism
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('determinism', () => {
+      it('generates identical output for same inputs', () => {
+        const signals: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        const result1 = deriveRecommendation(signals);
+        const result2 = deriveRecommendation(signals);
+        expect(result1).toBe(result2);
+      });
+
+      it('generates identical output for equivalent objects', () => {
+        const signals1: CopilotSignals = {
+          market: { fxVolatilityLevel: 'low', marketStatus: 'normal' },
+          yield: { yieldAvailability: 'normal', yieldRiskLevel: 'low' },
+          user: { recentDeposit: false, liquiditySensitivity: 'low' },
+        };
+        const signals2: CopilotSignals = {
+          market: { fxVolatilityLevel: 'low', marketStatus: 'normal' },
+          yield: { yieldAvailability: 'normal', yieldRiskLevel: 'low' },
+          user: { recentDeposit: false, liquiditySensitivity: 'low' },
+        };
+        expect(deriveRecommendation(signals1)).toBe(deriveRecommendation(signals2));
+      });
+
+      it('is consistent across multiple calls', () => {
+        const testCases: Array<{ signals: CopilotSignals; expected: CopilotRecommendation }> = [
+          { signals: {}, expected: 'wait' },
+          { signals: { market: stableMarket, yield: stableYield, user: stableUser }, expected: 'proceed' },
+          { signals: { market: elevatedMarket, yield: elevatedYield, user: recentDepositUser }, expected: 'proceed_cautiously' },
+          { signals: { market: highVolatilityMarket, yield: stableYield, user: stableUser }, expected: 'wait' },
+        ];
+
+        for (const { signals, expected } of testCases) {
+          for (let i = 0; i < 10; i++) {
+            expect(deriveRecommendation(signals)).toBe(expected);
+          }
+        }
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Environment Signal Exclusion
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('environment signal exclusion', () => {
+      it('does not affect recommendation in dev environment', () => {
+        const signals: CopilotSignals = {
+          environment: { environment: 'dev' },
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('does not affect recommendation in stg environment', () => {
+        const signals: CopilotSignals = {
+          environment: { environment: 'stg' },
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('does not affect recommendation in prod environment', () => {
+        const signals: CopilotSignals = {
+          environment: { environment: 'prod' },
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(signals)).toBe('proceed');
+      });
+
+      it('produces same result with or without environment signal', () => {
+        const withEnv: CopilotSignals = {
+          environment: { environment: 'prod' },
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        const withoutEnv: CopilotSignals = {
+          market: stableMarket,
+          yield: stableYield,
+          user: stableUser,
+        };
+        expect(deriveRecommendation(withEnv)).toBe(deriveRecommendation(withoutEnv));
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Return Type Validation
+    // ────────────────────────────────────────────────────────────────────────
+
+    describe('return type validation', () => {
+      it('always returns a valid CopilotRecommendation', () => {
+        const validRecommendations = ['proceed', 'proceed_cautiously', 'wait'];
+        const testCases: CopilotSignals[] = [
+          {},
+          { market: stableMarket },
+          { market: stableMarket, yield: stableYield },
+          { market: stableMarket, yield: stableYield, user: stableUser },
+          { market: highVolatilityMarket, yield: stableYield, user: stableUser },
+          { market: elevatedMarket, yield: elevatedYield, user: recentDepositUser },
+        ];
+
+        for (const signals of testCases) {
+          const result = deriveRecommendation(signals);
+          expect(validRecommendations).toContain(result);
+        }
+      });
+
+      it('never throws regardless of input', () => {
+        const edgeCases = [
+          {},
+          { market: null as any },
+          { market: undefined },
+          { market: {} as any },
+          { market: stableMarket, yield: null as any, user: stableUser },
+          { market: stableMarket, yield: stableYield, user: { recentDeposit: null as any, liquiditySensitivity: 'low' } },
+        ];
+
+        for (const signals of edgeCases) {
+          expect(() => deriveRecommendation(signals)).not.toThrow();
+        }
+      });
+    });
+  });
+});

--- a/apps/frontend/lib/server/copilotSignals.ts
+++ b/apps/frontend/lib/server/copilotSignals.ts
@@ -1,0 +1,253 @@
+/**
+ * Copilot Signal Mapping Engine
+ *
+ * Deterministic, trust-first signal-to-recommendation mapping.
+ * This module is server-only and must never be imported by client code.
+ *
+ * Design Principles (Non-Negotiable):
+ * - Fail-safe defaults: missing, conflicting, or ambiguous signals → wait
+ * - Determinism: same inputs always produce the same output
+ * - No implicit knowledge: signals must be explicitly provided
+ * - Trust > Growth: never optimize for action; "proceed" is allowed, not a goal
+ *
+ * Security boundaries:
+ * - No user input accepted
+ * - No process.env reads (accepts params only)
+ * - Deterministic (same inputs always produce same output)
+ * - No I/O operations
+ * - Must not throw
+ *
+ * @module lib/server/copilotSignals
+ */
+
+// ============================================================================
+// Signal Type Definitions (SSoT)
+// ============================================================================
+
+export type EnvironmentSignal = {
+  environment: "dev" | "stg" | "prod";
+};
+
+export type MarketSignal = {
+  fxVolatilityLevel: "low" | "elevated" | "high";
+  marketStatus: "normal" | "uncertain";
+};
+
+export type YieldSignal = {
+  yieldAvailability: "normal" | "reduced" | "uncertain";
+  yieldRiskLevel: "low" | "elevated";
+};
+
+export type UserSignal = {
+  recentDeposit: boolean;
+  liquiditySensitivity: "low" | "medium" | "high";
+};
+
+/**
+ * Copilot signal input model.
+ *
+ * All top-level signal groups are optional to support incremental rollout.
+ * Absence of any required group triggers conservative handling.
+ *
+ * Note: `environment` is included for completeness but is excluded from
+ * recommendation logic in v1. It may be used for logging/auditing only.
+ */
+export type CopilotSignals = {
+  environment?: EnvironmentSignal;
+  market?: MarketSignal;
+  yield?: YieldSignal;
+  user?: UserSignal;
+};
+
+// ============================================================================
+// Recommendation Output (Canonical)
+// ============================================================================
+
+/**
+ * The only valid recommendation outputs.
+ * No other outputs are permitted.
+ */
+export type CopilotRecommendation = "proceed" | "proceed_cautiously" | "wait";
+
+// ============================================================================
+// Internal Validation Helpers
+// ============================================================================
+
+const VALID_FX_VOLATILITY_LEVELS = ["low", "elevated", "high"] as const;
+const VALID_MARKET_STATUSES = ["normal", "uncertain"] as const;
+const VALID_YIELD_AVAILABILITIES = ["normal", "reduced", "uncertain"] as const;
+const VALID_YIELD_RISK_LEVELS = ["low", "elevated"] as const;
+const VALID_LIQUIDITY_SENSITIVITIES = ["low", "medium", "high"] as const;
+
+/**
+ * Validates that a MarketSignal has all required fields with valid values.
+ */
+function isValidMarketSignal(signal: MarketSignal | undefined): signal is MarketSignal {
+  if (!signal) return false;
+  if (!VALID_FX_VOLATILITY_LEVELS.includes(signal.fxVolatilityLevel as typeof VALID_FX_VOLATILITY_LEVELS[number])) return false;
+  if (!VALID_MARKET_STATUSES.includes(signal.marketStatus as typeof VALID_MARKET_STATUSES[number])) return false;
+  return true;
+}
+
+/**
+ * Validates that a YieldSignal has all required fields with valid values.
+ */
+function isValidYieldSignal(signal: YieldSignal | undefined): signal is YieldSignal {
+  if (!signal) return false;
+  if (!VALID_YIELD_AVAILABILITIES.includes(signal.yieldAvailability as typeof VALID_YIELD_AVAILABILITIES[number])) return false;
+  if (!VALID_YIELD_RISK_LEVELS.includes(signal.yieldRiskLevel as typeof VALID_YIELD_RISK_LEVELS[number])) return false;
+  return true;
+}
+
+/**
+ * Validates that a UserSignal has all required fields with valid values.
+ */
+function isValidUserSignal(signal: UserSignal | undefined): signal is UserSignal {
+  if (!signal) return false;
+  if (typeof signal.recentDeposit !== "boolean") return false;
+  if (!VALID_LIQUIDITY_SENSITIVITIES.includes(signal.liquiditySensitivity as typeof VALID_LIQUIDITY_SENSITIVITIES[number])) return false;
+  return true;
+}
+
+// ============================================================================
+// Unsafe Condition Detection
+// ============================================================================
+
+/**
+ * Determines if any unsafe condition is present in the signals.
+ *
+ * Unsafe conditions trigger immediate "wait" recommendation.
+ * These represent elevated risk that warrants conservative behavior.
+ *
+ * @param market - Validated market signal
+ * @param yieldSignal - Validated yield signal
+ * @param user - Validated user signal
+ * @returns true if any unsafe condition is detected
+ */
+function isUnsafe(
+  market: MarketSignal,
+  yieldSignal: YieldSignal,
+  user: UserSignal
+): boolean {
+  // Market uncertainty → unsafe (cannot confidently assess conditions)
+  if (market.marketStatus === "uncertain") return true;
+
+  // High FX volatility → unsafe (currency risk too elevated)
+  if (market.fxVolatilityLevel === "high") return true;
+
+  // Yield availability uncertain → unsafe (cannot predict returns)
+  if (yieldSignal.yieldAvailability === "uncertain") return true;
+
+  // High liquidity sensitivity → unsafe (user cannot tolerate lock-ups)
+  if (user.liquiditySensitivity === "high") return true;
+
+  return false;
+}
+
+// ============================================================================
+// Recommendation Derivation (Public API)
+// ============================================================================
+
+/**
+ * Derives a recommendation from the provided signals.
+ *
+ * This is the canonical recommendation engine for Hedgr Copilot.
+ * It is a pure function that:
+ * - Does not read from process.env
+ * - Does not throw
+ * - Always returns a valid CopilotRecommendation
+ * - Produces deterministic output for the same input
+ *
+ * Decision logic (in order):
+ * 1. Missing/invalid signals → wait (trust-first default)
+ * 2. Unsafe conditions → wait (risk mitigation)
+ * 3. Cautious conditions → proceed_cautiously (elevated but manageable risk)
+ * 4. Stable conditions → proceed (all clear)
+ * 5. Fallback → wait (no implicit "proceed")
+ *
+ * Note: The `environment` signal is excluded from recommendation logic in v1.
+ * It is reserved for logging, auditing, and future extensibility.
+ *
+ * @param signals - The copilot signals to evaluate
+ * @returns The recommendation: "proceed", "proceed_cautiously", or "wait"
+ */
+export function deriveRecommendation(signals: CopilotSignals): CopilotRecommendation {
+  // ──────────────────────────────────────────────────────────────────────────
+  // Guard: Missing or invalid signals → wait (trust-first default)
+  // ──────────────────────────────────────────────────────────────────────────
+  // Missing information = uncertainty → conservative default is to wait.
+  // This includes both missing signal objects and invalid field values.
+
+  if (!isValidMarketSignal(signals.market)) {
+    return "wait";
+  }
+
+  if (!isValidYieldSignal(signals.yield)) {
+    return "wait";
+  }
+
+  if (!isValidUserSignal(signals.user)) {
+    return "wait";
+  }
+
+  // At this point, all required signals are validated
+  const { market } = signals;
+  const yieldSignal = signals.yield;
+  const { user } = signals;
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Guard: Unsafe conditions → wait (risk mitigation)
+  // ──────────────────────────────────────────────────────────────────────────
+  // Any single unsafe condition is sufficient to recommend waiting.
+  // This prevents action under elevated risk.
+
+  if (isUnsafe(market, yieldSignal, user)) {
+    return "wait";
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Check: Cautious conditions → proceed_cautiously
+  // ──────────────────────────────────────────────────────────────────────────
+  // All of the following must be true:
+  // - Market status is normal (no systemic concerns)
+  // - FX volatility is elevated but not high (manageable currency risk)
+  // - Yield risk is elevated (higher than normal but acceptable)
+  // - User has a recent deposit (actively engaged)
+
+  const isCautious =
+    market.marketStatus === "normal" &&
+    market.fxVolatilityLevel === "elevated" &&
+    yieldSignal.yieldRiskLevel === "elevated" &&
+    user.recentDeposit === true;
+
+  if (isCautious) {
+    return "proceed_cautiously";
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Check: Stable conditions → proceed
+  // ──────────────────────────────────────────────────────────────────────────
+  // All of the following must be true:
+  // - Market status is normal (no systemic concerns)
+  // - FX volatility is low (minimal currency risk)
+  // - Yield risk is low (predictable returns)
+  // - User liquidity sensitivity is not high (already checked above)
+
+  const isStable =
+    market.marketStatus === "normal" &&
+    market.fxVolatilityLevel === "low" &&
+    yieldSignal.yieldRiskLevel === "low" &&
+    user.liquiditySensitivity !== "high"; // redundant but explicit for clarity
+
+  if (isStable) {
+    return "proceed";
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Fallback: wait (non-negotiable)
+  // ──────────────────────────────────────────────────────────────────────────
+  // If no rule above matched exactly, default to waiting.
+  // There is no implicit "proceed". This is foundational to Hedgr's trust posture.
+
+  return "wait";
+}


### PR DESCRIPTION
## Summary

- Implement copilot signal-to-recommendation engine per S09-COPILOT-DATA-SIGNALS spec
- Add deterministic `deriveRecommendation()` pure function with trust-first defaults
- Add comprehensive test suite (38 tests) covering all mapping rules

## Acceptance Criteria

- [x] Signal types defined: `EnvironmentSignal`, `MarketSignal`, `YieldSignal`, `UserSignal`
- [x] `CopilotRecommendation` type: `proceed | proceed_cautiously | wait`
- [x] Missing/invalid signals → `wait`
- [x] Unsafe conditions → `wait` (high volatility, uncertain market, uncertain yield, high liquidity sensitivity)
- [x] Cautious conditions → `proceed_cautiously`
- [x] Stable conditions → `proceed`
- [x] Fallback → `wait` (no implicit proceed)
- [x] Environment signal excluded from v1 recommendation logic (documented)
- [x] Pure function: no I/O, no randomness, no process.env reads, never throws

## Test Plan

- [x] Missing signals → wait (5 tests)
- [x] Invalid signal fields → wait (7 tests)
- [x] Unsafe conditions → wait (5 tests)
- [x] Conflicting signals → wait (2 tests)
- [x] Stable conditions → proceed (4 tests)
- [x] Cautious conditions → proceed_cautiously (2 tests)
- [x] Fallback → wait (4 tests)
- [x] Determinism (3 tests)
- [x] Environment signal exclusion (4 tests)
- [x] Return type validation (2 tests)

## Files Changed

- `apps/frontend/lib/server/copilotSignals.ts` - Signal types and deriveRecommendation function
- `apps/frontend/__tests__/copilotSignals.test.ts` - Comprehensive test suite

## Related Tickets

- S09-COPILOT-DATA-SIGNALS
- Ticket 4 — S09-COPILOT-PROMPT-ARCHITECTURE
- Ticket 6 — S09-COPILOT-POLICY-ENFORCEMENT