### PR TITLE
docs(S09-DOCS-FLAGS): Copilot flags, rollout, and rollback documentation

### DIFF
--- a/docs/copilot/flags-and-rollout.md
+++ b/docs/copilot/flags-and-rollout.md
@@ -1,0 +1,274 @@
+# Hedgr Copilot — Flags, Rollout & Rollback
+
+**Status:** Authoritative  
+**Applies to:** Sprint 0.9+  
+**Audience:** Engineering, Product, On-call, QA
+
+---
+
+## 1. Overview
+
+Hedgr Copilot is a trust-first, advisory-only AI assistant designed to help users understand Hedgr, their balances, and system state.
+
+Copilot is intentionally gated behind multiple environment flags to ensure:
+
+- Safe rollout
+- Controlled experimentation
+- Immediate rollback in incidents
+- Zero ambiguity about trust posture
+
+This document is the single source of truth for how Copilot is enabled, disabled, and operated.
+
+---
+
+## 2. Trust & Safety Posture (Invariant)
+
+The following principles are non-negotiable and enforced by code + tests:
+
+- Copilot is not a financial advisor
+- No investment, trading, or regulatory advice
+- No guarantees, APY claims, or urgency language
+- "Waiting" is a valid and encouraged recommendation
+- User control is always reinforced
+- Safety > engagement > growth
+
+**If any of these principles are violated, Copilot must be disabled immediately using the rollback steps below.**
+
+---
+
+## 3. Environment Variables (Authoritative)
+
+### 3.1 OPENAI_MODE
+
+**Purpose**  
+Controls whether Copilot uses a real OpenAI model or a stubbed deterministic model.
+
+**Allowed Values**
+
+- `stub` (default)
+- `live`
+
+**Defaults**
+
+| Environment | Value          |
+| ----------- | -------------- |
+| CI          | `stub` (forced) |
+| dev         | `stub`         |
+| stg         | `stub`         |
+| prod        | `stub`         |
+
+**Behavior**
+
+- `stub`: No external network calls. Deterministic responses.
+- `live`: Uses OpenAI API (requires `OPENAI_API_KEY`).
+
+**Failure Mode**
+
+- If `OPENAI_MODE=live` and `OPENAI_API_KEY` is missing → Copilot API returns 503.
+
+**Rollback**
+
+```bash
+OPENAI_MODE=stub
+```
+
+No rebuild required (server-side).
+
+---
+
+### 3.2 FEATURE_COPILOT_ENABLED / NEXT_PUBLIC_FEATURE_COPILOT_ENABLED
+
+**Purpose**  
+Controls UI and route exposure for Copilot (`/chat`).
+
+> **Critical Detail**  
+> This is a **build-time flag**.  
+> It must be set before `next build`.
+
+**Allowed Values**
+
+- `true`
+- `false` (default)
+
+**Defaults**
+
+| Environment | Value                              |
+| ----------- | ---------------------------------- |
+| CI          | `false` (unless explicitly enabled for E2E) |
+| dev         | `false`                            |
+| stg         | `false`                            |
+| prod        | `false`                            |
+
+**Behavior**
+
+- `false`:
+  - `/chat` redirects to `/dashboard`
+  - Copilot nav item hidden
+- `true`:
+  - `/chat` available
+  - Copilot UI visible
+
+**Rollback (Immediate UI Kill)**
+
+```bash
+NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=false pnpm build
+```
+
+Deploy rebuilt artifact.
+
+---
+
+### 3.3 COPILOT_CACHE_ENABLED
+
+**Purpose**  
+Controls semantic response caching for Copilot.
+
+**Allowed Values**
+
+- `true` (default)
+- `false`
+
+**Behavior**
+
+- `true`: Cached responses reused (cost + latency reduction)
+- `false`: All requests hit model/stub
+
+**Safety**
+
+- Safe to disable at any time
+- No user-visible breakage
+
+**Rollback**
+
+```bash
+COPILOT_CACHE_ENABLED=false
+```
+
+No rebuild required.
+
+---
+
+## 4. Rollout Procedure (Canonical)
+
+### Step 1 — Enable in Dev
+
+```bash
+NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=true OPENAI_MODE=stub pnpm build
+```
+
+Validate:
+
+- `/chat` accessible
+- Stub responses
+- Disclaimers visible
+
+---
+
+### Step 2 — Enable in Staging
+
+Same as dev. Validate:
+
+- E2E safety tests
+- Refusal behavior
+- Outage resilience
+
+---
+
+### Step 3 — (Optional) Enable Live OpenAI
+
+```bash
+OPENAI_MODE=live
+```
+
+Requirements:
+
+- API key present
+- Logs monitored
+- Rollback ready
+
+---
+
+### Step 4 — Limited Production Exposure
+
+- Feature flag remains primary kill switch
+- Do not enable live OpenAI by default
+
+---
+
+## 5. Rollback Playbooks (Explicit)
+
+### 5.1 Emergency: Disable Copilot UI
+
+```bash
+NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=false pnpm build
+```
+
+**Effect:**
+
+- `/chat` disabled
+- No user access
+- Safest rollback
+
+---
+
+### 5.2 Disable OpenAI Only (Keep UI)
+
+```bash
+OPENAI_MODE=stub
+```
+
+**Effect:**
+
+- Copilot remains available
+- No external calls
+
+---
+
+### 5.3 Disable Semantic Cache
+
+```bash
+COPILOT_CACHE_ENABLED=false
+```
+
+**Effect:**
+
+- Higher cost / latency
+- Maximum determinism
+
+---
+
+### 5.4 Full Dark Launch
+
+```bash
+NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=false
+OPENAI_MODE=stub
+COPILOT_CACHE_ENABLED=false
+pnpm build
+```
+
+---
+
+## 6. CI & E2E Safety Notes
+
+- Safety E2E tests require:
+
+```bash
+NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=true pnpm build
+```
+
+- Tests will fail intentionally if Copilot is unavailable.
+- This is a safety gate, not a flake.
+
+---
+
+## 7. Ownership & Accountability
+
+- Feature flags are the first response, not code changes
+- Tests are allowed to fail loudly
+- Trust violations override growth concerns
+
+---
+
+## 8. Change Log
+
+- **Sprint 0.9:** Initial Copilot rollout controls documented

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -44,3 +44,11 @@ Do **not** commit `.env*` files.
 ## Health/Version (for smoke checks)
 - `/api/health` → `200 { status: "ok", ts: "<ISO>" }`
 - `/api/version` → `200 { version: "<apps/frontend package version>" }`
+
+---
+
+## Copilot Feature Flags
+
+For Copilot-specific flags (`OPENAI_MODE`, `FEATURE_COPILOT_ENABLED`, `COPILOT_CACHE_ENABLED`), rollout procedures, and rollback playbooks, see:
+
+> **[docs/copilot/flags-and-rollout.md](./copilot/flags-and-rollout.md)** — Single source of truth for Copilot ops


### PR DESCRIPTION
Add authoritative SSoT documentation for Copilot operational controls:
- Trust & safety posture (invariants)
- Flag definitions (OPENAI_MODE, FEATURE_COPILOT_ENABLED, COPILOT_CACHE_ENABLED)
- Build-time vs runtime distinction
- Rollout procedure (canonical)
- Rollback playbooks (copy-pastable)
- CI/E2E requirements

Link added to docs/secrets.md for discoverability.

<!--
This PR template is a self-attestation.
CI, branch protection, and Codex QA remain the final authority.
Unchecked or inaccurate items may block merge.
-->

## Summary
<!-- 1–3 lines. What changed and why. Link CONTRACT / micro-contract if applicable. -->

## Scope
**In**
- 

**Out**
- 

## Acceptance Criteria (Gherkin)
- [ ] Given … When … Then …

---

## Tests (author attestation)
- [x] Unit tests added/updated where logic changed
- [x] E2E updated/added if user flows or critical paths changed

> Note: CI enforces test execution. This section confirms *intent and coverage*, not pass/fail.

---

## Merge Gates (system-enforced)
**Required checks**
- validate (unit, typecheck, lint)
- E2E smoke (@hedgr/frontend)

**Required labels**
- `product:approved` (HedgrOps)
- `qa:approved` (Codex QA)
- one `area:*`
- one `risk:*`

---

## Rollback Strategy
<!-- How can this be safely undone? -->
- [x] Single revert commit
- [x] Flag flip back to defaults (`mock` / `fixed`)
- [x] No irreversible data migration

---

## Security & Trust (non-negotiable)
- [x] No secrets introduced or exercised in CI
- [x] Analytics and live networks blocked in tests
- [x] Server-only secrets remain server-only

---

## PR Checklist (prevent CI footguns)

### Routing & Architecture
- [x] No duplicate routes across `pages/*` and `app/*`
- [x] New routes follow the repo’s current routing convention

### Flags & Environments
- [x] CI defaults unchanged (`AUTH_MODE=mock`, `FX_MODE=fixed`, `DEFI_MODE=mock`)
- [x] Live providers (Magic, CoinGecko, Aave) are **flag-guarded** and local-only
- [x] No code path can accidentally hit live services in CI/E2E

### Tests & State
- [x] Browser-dependent tests explicitly use `jsdom`
- [x] Zustand persistence tests rely on deterministic storage
- [x] No reliance on real time, real network, or implicit globals

### E2E (Playwright)
- [x] Locators use **roles or `data-testid`**
- [x] No ambiguous `getByText()` in strict mode
- [x] E2E remains hermetic and deterministic

### Build & Determinism
- [x] Local verification run:
  ```bash
  pnpm -w build
  pnpm -w test
  pnpm --filter @hedgr/frontend run e2e:ci