### PR TITLE
docs(ops): add HEDGR retail UI pass resolution note

### DIFF
--- a/docs/ops/HEDGR_RETAIL_UI_PASS_RESOLUTION_NOTE.md
+++ b/docs/ops/HEDGR_RETAIL_UI_PASS_RESOLUTION_NOTE.md
@@ -1,0 +1,375 @@
+# HEDGR RETAIL UI PASS RESOLUTION NOTE
+
+Status: Critique resolution only  
+Authority: Non-sequencing, non-implementation  
+Scope: Resolution of founder pass and external critique signal for bounded retail dashboard refinement  
+Last updated: 2026-04-14
+
+---
+
+## 1. Purpose
+
+This note records the current resolution of the latest retail UI pass feedback.
+
+It exists to:
+
+1. capture what the pass correctly identified
+2. distinguish between changes to absorb now, translate before use, and defer
+3. preserve alignment between founder intent and critique signal
+4. keep the next refinement cycle governed and bounded
+
+This document does **not**:
+
+- authorize implementation
+- approve a final UI direction
+- create sequencing authority
+- override `docs/ops/HEDGR_STATUS.md`
+- function as an ADR or decision log
+
+This is a pass-resolution artifact only.
+
+---
+
+## 2. Foundational alignment
+
+Current founder position:
+
+> The UI is in the ballpark of expectation regarding UX and emotionality. The goal is to stay governed in layering meaning onto calm money.
+
+This is the governing read for this pass.
+
+The implication is:
+
+- the emotional lane is broadly correct
+- the screen is beginning to feel category-defining rather than generic
+- the next job is not to make the interface louder
+- the next job is to add meaning carefully, without disturbing the calm money posture
+
+This note resolves the pass against that standard.
+
+---
+
+## 3. Core read from the pass
+
+The strongest signal in the critique is that Hedgr is moving toward a product that shows not just **money**, but the **condition of money**.
+
+That is strategically important.
+
+The pass correctly identified that:
+
+- the portfolio card is working as the emotional anchor
+- stability status is becoming a defining product surface
+- action hierarchy is stronger when context precedes movement
+- allocation is increasingly acting as the trust layer
+- the main weaknesses are no longer visual polish issues
+- the main weaknesses are meaning, consequence, and structural legibility
+
+This is the correct level of pressure.
+
+---
+
+## 4. Working interpretation
+
+The pass does **not** mean Hedgr should become more complex, more operational, or more system-authored.
+
+The pass means Hedgr should become:
+
+- more legible
+- more meaningful
+- more interpretable
+- more structurally honest
+
+without losing:
+
+- calmness
+- money-first posture
+- trust restraint
+- governance discipline
+
+The right direction remains:
+
+**layer meaning onto calm money**
+
+Not:
+
+- layer machinery onto calm money
+- expose the full engine
+- or drift into dashboard theater
+
+---
+
+## 5. Resolution categories
+
+This pass is resolved across three buckets:
+
+1. **Accept now**
+2. **Translate before use**
+3. **Defer for later doctrine / system maturity**
+
+---
+
+## 6. Accept now
+
+These signals are strong enough to act on in the next critique/refinement cycle.
+
+### 6.1 Stability Status needs more meaning
+
+Accepted.
+
+The critique is correct that the current status layer risks reading as too atmospheric if it lacks explanatory consequence.
+
+Resolution:
+- keep Stability Status
+- add a light supporting sentence beneath it in future refinement exploration
+- keep the explanation bounded and calm
+
+Example direction:
+- `Balanced`
+- `Your funds are within the current protection range.`
+
+This should remain interpretive, not operational.
+
+### 6.2 Allocation needs stronger immediate legibility
+
+Accepted.
+
+The critique is correct that the allocation layer currently reads as informative, but still slightly passive.
+
+Resolution:
+- explore more immediate visual weighting
+- make distribution easier to grasp at a glance
+- preserve the allocation layer as trust surface, not performance theater
+
+This should improve readability, not excitement.
+
+### 6.3 Activity naming should be revisited
+
+Accepted.
+
+The critique is correct that the current activity naming may still be provisional.
+
+Resolution:
+- test alternate bounded naming for the activity layer
+- keep the role narrow
+- do not expand the surface while testing labels
+
+Likely near-term candidates:
+- `Money activity`
+- `Recent activity`
+- `Money flow`
+- `Recent movement`
+
+This is a naming refinement, not an IA expansion.
+
+### 6.4 Action symmetry should be questioned
+
+Accepted.
+
+The critique is correct that equal-weight action treatment risks pulling the surface back toward generic fintech.
+
+Resolution:
+- test whether one primary movement action should carry more weight than the other
+- preserve the principle that action remains subordinate to state
+- avoid introducing higher-agency language too early
+
+This is a hierarchy question, not a feature question.
+
+---
+
+## 7. Translate before use
+
+These signals are directionally strong, but must be translated into Hedgr-safe form before they are used in the product language.
+
+### 7.1 “Condition of wealth” as the product frame
+
+Translate before use.
+
+This is strategically one of the strongest insights in the pass, but it should remain an internal framing lens unless explicitly codified.
+
+Working internal translation:
+- Hedgr is not only showing money
+- it is showing the condition and protection posture of money
+
+Use:
+- as internal product framing
+- as critique guidance
+- as meaning architecture
+
+Do not yet use:
+- as public-facing marketing copy
+- as direct UI wording
+- as ungoverned doctrine language
+
+### 7.2 Stability Status as a visible system
+
+Translate before use.
+
+The pass is right that status should feel meaningful.  
+But the answer is not to expose a full visible state machine too early.
+
+Resolution:
+- define a bounded retail-facing status vocabulary first
+- attach one-line meanings
+- ensure each label implies only what the current system can honestly support
+
+This should become a governed status model, not an expressive status theater.
+
+### 7.3 Guidance layer beneath status
+
+Translate before use.
+
+The critique correctly spots an opportunity for a light guidance layer.  
+But this is governance-sensitive because it can quickly drift into advisory behavior.
+
+Resolution:
+- define whether such guidance is informative, advisory, or mixed
+- define when it appears
+- define what it may imply
+- define what it must never imply
+
+Only after that should it be explored in UI form.
+
+### 7.4 Transaction feed reframing
+
+Translate before use.
+
+The pass is right that the current activity section risks feeling too bank-native relative to the rest of the screen.
+
+Resolution:
+- preserve legibility of ordinary money activity
+- avoid overcorrecting into abstract “system flow” language too early
+- test naming and light classification first before changing the section’s conceptual role
+
+---
+
+## 8. Defer for later doctrine / system maturity
+
+These ideas should not be acted on in the current pass.
+
+### 8.1 Full visible stability state machine
+
+Deferred.
+
+Internally, yes, Hedgr needs stronger state logic.  
+Retail-facing, no, not yet.
+
+Reason:
+- risks over-claiming maturity
+- adds governance burden
+- may imply deterministic behavior the current surface cannot justify
+
+### 8.2 Strong retail risk labels such as “At risk”
+
+Deferred.
+
+These may become valid later, but not until:
+- thresholds are real
+- communications doctrine is tighter
+- consequence logic is defined
+- trust/legal implications are understood
+
+For now, calmer bounded status language remains preferable.
+
+### 8.3 Rebalance / Stabilise as top-layer actions
+
+Deferred.
+
+These labels imply:
+- user control over system-level allocation
+- stronger intervention semantics
+- more mature engine-actuation language than the current posture supports
+
+Not appropriate for this pass.
+
+### 8.4 Rich motion-based allocation feedback
+
+Deferred.
+
+The pass’s instinct toward stronger allocation expression is useful, but movement and animated change should not be used to create perceived sophistication or reward behavior.
+
+Static clarity should be exhausted before motion is considered.
+
+---
+
+## 9. Current pass resolution
+
+### 9.1 What this pass validated
+
+This pass validated that the UI is broadly in the right lane:
+
+- calm
+- premium
+- emotionally stable
+- structurally promising
+- increasingly differentiated
+
+### 9.2 What this pass exposed
+
+This pass exposed that the next bottleneck is not aesthetics.
+
+It is the product meaning architecture behind:
+
+- Stability Status
+- allocation interpretation
+- activity naming
+- action hierarchy
+- disclosure of condition without overstating system maturity
+
+### 9.3 What this pass did not justify
+
+This pass did not justify:
+
+- exposing a richer visible engine
+- turning the UI into a control system
+- escalating action semantics
+- moving into more assertive risk-state language
+- productizing ungoverned status logic
+
+---
+
+## 10. Recommended next actions
+
+The next refinement cycle should focus on:
+
+1. testing a one-line supporting sentence under Stability Status
+2. exploring stronger allocation legibility without making it louder
+3. testing alternate bounded naming for the activity layer
+4. testing asymmetry in action emphasis
+5. defining a first-pass retail-facing status vocabulary
+
+These should remain critique/refinement exercises unless later sequenced explicitly.
+
+---
+
+## 11. Working conclusion
+
+The founder read is correct.
+
+The UI is in the right emotional ballpark.  
+The next challenge is not more visual invention.
+
+It is controlled meaning.
+
+The strongest lesson from this pass is:
+
+**Hedgr is strongest when it layers governed meaning onto calm money, not when it exposes more machinery.**
+
+That is the resolution.
+
+---
+
+## 12. Closing position
+
+This pass should move the work forward, but not widen it.
+
+The current posture should remain:
+
+- calm first
+- money first
+- status meaningful, but bounded
+- trust visible, but not theatrical
+- structure legible, but not system-heavy
+
+The goal is not to make Hedgr feel more active.
+
+It is to make Hedgr feel more trustworthy because its meaning is clearer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `docs/ops/HEDGR_RETAIL_UI_PASS_RESOLUTION_NOTE.md` as a critique-resolution artifact recording the resolution of the latest retail UI pass feedback (non-sequencing, non-implementation).

This change is documentation only; no code or behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fe2a4a2-517a-4a47-b889-f16540736c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fe2a4a2-517a-4a47-b889-f16540736c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

