### PR TITLE
docs(ops): close out MC-S3-013 PR references in HEDGR_STATUS

### DIFF
--- a/docs/ops/HEDGR_STATUS.md
+++ b/docs/ops/HEDGR_STATUS.md
@@ -375,7 +375,7 @@ Implementation truth:
 Implementation posture preserved:
 
 - **test-only** runtime posture; **no** `EngineState` semantic change, **no** new `EnginePosture` values, **no** new trust states, **no** execution or accounting wording, **no** backend engine binding, and **no** live network behavior
-- no ADR under ticket intent; merged PR **pending**
+- no ADR under ticket intent; merged PR **#134**
 
 ### MC-S2-004 - Allocation bands UI
 
@@ -792,7 +792,7 @@ Completed and merged:
 - `MC-S3-011` - Stability Engine trust-surface coverage matrix (documentation only; merged PR **#125**; completed record **§42**)
 - `MC-S3-012` - Retail UI money-first shell prototype-only bounded spike (presentation-only, prototype-route scope; merged PR **pending**; completed record **§43**; readout artifact **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**)
 - `UI-SRA-001` - Shipped retail dashboard adaptation to settled money-first reference surface (bounded `app/(app)/dashboard/**` presentation-only; merged PR **#132**; completed record **§44**; readout **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_READOUT.md`**)
-- `MC-S3-013` - Canonical engine type export contract (test-only; merged PR **pending**; completed record **§45**)
+- `MC-S3-013` - Canonical engine type export contract (test-only; merged PR **#134**; completed record **§45**)
 
 Current active ticket status:
 
@@ -807,7 +807,7 @@ Current active ticket status:
 - Cursor must not continue automatically into work beyond what is explicitly defined in this file for an active ticket.
 - Cursor must not drift beyond explicitly defined scope.
 
-**Last completed ticket (summary):** `MC-S3-013` — Canonical engine type export contract (test-only; dedicated `apps/frontend/__tests__/engine-types-contract.test.ts`; `MC-S2-001` matrix row moved to **Covered**; no `EngineState` semantics, posture states, execution wording, accounting wording, backend binding, or live-network behavior); merged PR **pending**; completed record in **§45**.
+**Last completed ticket (summary):** `MC-S3-013` — Canonical engine type export contract (test-only; dedicated `apps/frontend/__tests__/engine-types-contract.test.ts`; `MC-S2-001` matrix row moved to **Covered**; no `EngineState` semantics, posture states, execution wording, accounting wording, backend binding, or live-network behavior); merged PR **#134**; completed record in **§45**.
 
 ---
 
@@ -819,7 +819,7 @@ When governance approves the next ticket, **§7** will name it and this section 
 
 ---
 
-**Archived brief (MC-S3-013):** Canonical engine type export contract — **test-only**; added **`apps/frontend/__tests__/engine-types-contract.test.ts`** to lock canonical `EnginePosture` union, required `EngineState` keys, optional `notice`, and `EngineNotice` title/body shape; updated **`docs/ops/HEDGR_STABILITY_ENGINE_TRUST_SURFACE_TEST_COVERAGE_MATRIX.md`** `MC-S2-001` row from **Partially covered** to **Covered**. **No** `apps/frontend/lib/engine/types.ts` semantics change, **no** new posture values or trust states, **no** execution/accounting wording, **no** `mock.ts`, **no** `useEngineState`, **no** dashboard components, **no** withdraw/tx/market seams, **no** backend, **no** live network. `MC-S3-004` notice/mock contract behavior preserved in intent. No ADR under ticket intent. Merged PR **pending**. Completed record: **§45**.
+**Archived brief (MC-S3-013):** Canonical engine type export contract — **test-only**; added **`apps/frontend/__tests__/engine-types-contract.test.ts`** to lock canonical `EnginePosture` union, required `EngineState` keys, optional `notice`, and `EngineNotice` title/body shape; updated **`docs/ops/HEDGR_STABILITY_ENGINE_TRUST_SURFACE_TEST_COVERAGE_MATRIX.md`** `MC-S2-001` row from **Partially covered** to **Covered**. **No** `apps/frontend/lib/engine/types.ts` semantics change, **no** new posture values or trust states, **no** execution/accounting wording, **no** `mock.ts`, **no** `useEngineState`, **no** dashboard components, **no** withdraw/tx/market seams, **no** backend, **no** live network. `MC-S3-004` notice/mock contract behavior preserved in intent. No ADR under ticket intent. Merged PR **#134**. Completed record: **§45**.
 
 **Archived brief (UI-SRA-001):** Shipped retail dashboard **structural alignment** to settled money-first reference — **presentation-only**; touched **`apps/frontend/app/(app)/dashboard/page.tsx`**, **`EnginePostureHeader.tsx`**, **`EngineAllocationBands.tsx`**, **`apps/frontend/tests-e2e/smoke-pack.spec.ts`**; **no** `apps/frontend/lib/engine/**`, **no** `layout.client.tsx`, **no** backend. Execution readout **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_READOUT.md`**. Support artifacts **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_REQUEST.md`**, **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_STATUS_PATCH_PROPOSAL.md`**. Merged PR **#132**. Completed record: **§44**. Governance lineage note in readout **§2** and **§7** reconciliation bullet above.
 
@@ -1807,7 +1807,7 @@ This **§43** record is written in the same working-tree change-set as the imple
 ## 45. Completed execution ticket - MC-S3-013 (Canonical engine type export contract)
 
 **Ticket:** `MC-S3-013` — Canonical engine type export contract (test-only)  
-**Branch / PR:** pending / **PR pending**
+**Branch / PR:** `cursor/mc-s3-013-engine-type-export-contract` / **PR #134**
 
 ### Outcome (test-only)
 
@@ -1817,7 +1817,7 @@ This **§43** record is written in the same working-tree change-set as the imple
 
 **Scope discipline held.** **No** `EngineState` semantics changed, **no** new `EnginePosture` values or trust states, **no** execution/accounting wording, **no** `apps/frontend/lib/engine/mock.ts`, **no** `useEngineState`, **no** dashboard components, **no** withdraw/tx/market seams, **no** backend, **no** live network behavior. **`MC-S3-004`** notice/mock contract behavior preserved in intent.
 
-**Validation.** `pnpm -w test` and `pnpm run validate` completed cleanly in the implementation workspace. Merged PR **pending**.
+**Validation.** `pnpm -w test` and `pnpm run validate` completed cleanly in the implementation workspace. Merged PR **#134**.
 
 ### Sequencing note
 


### PR DESCRIPTION
### Motivation
- Ensure repository governance and merged-truth consistency by replacing lingering “merged PR pending” placeholders for `MC-S3-013` with the actual PR reference so `docs/ops/HEDGR_STATUS.md` accurately reflects the merged state.

### Description
- Updated `docs/ops/HEDGR_STATUS.md` to replace `merged PR **pending**` placeholders for `MC-S3-013` with `PR #134` across the merged-truth subsection, the completed-ticket list, the §7a archived brief, and the §45 branch/PR and validation lines.
- Filled the `§45` branch/PR line with `cursor/mc-s3-013-engine-type-export-contract` and updated the Validation sentence to reference the merged PR number for post-merge consistency.
- This is a documentation-only change and does not modify product code, runtime behavior, ADRs, or tests.

### Testing
- Ran targeted textual verification using repository search to confirm all `MC-S3-013` `pending` occurrences were replaced by `#134` via `rg -n "MC-S3-013|PR \*\*pending\*\*|Branch / PR" docs/ops/HEDGR_STATUS.md`, which returned the updated locations.
- Inspected the updated sections with `nl -ba docs/ops/HEDGR_STATUS.md | sed -n '350,390p;788,835p;1804,1823p'` to validate the replacements in-context and the inserted branch/PR line.
- Performed a file-level consistency pass on `docs/ops/HEDGR_STATUS.md` to ensure no unrelated text was changed and found no issues.
- No unit or integration test runs were required because this change is docs-only and does not affect code or CI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19403f04c8332a6f26790a61ab2ed)