### PR TITLE
docs(ops): reconcile MC-S3-012 status truth

### DIFF
--- a/docs/agents/skills/codex-implementer.md
+++ b/docs/agents/skills/codex-implementer.md
@@ -63,6 +63,62 @@ You MUST NOT:
 If conflict is detected:
 → STOP and surface explicitly
 
+
+---
+
+## Hedgr Usage Pattern: Execute Active Ticket
+
+Use this pattern only after `docs/ops/HEDGR_STATUS.md` §7 / §7a names a single active ticket.
+
+### Purpose
+
+Implement the active ticket exactly as defined in repo-native execution truth.
+
+### Required Inputs
+
+- **Task Description**: active ticket from `docs/ops/HEDGR_STATUS.md` §7 / §7a
+- **Scope**: exact files or directories named or implied by the ticket brief
+- **Acceptance Criteria**: criteria from §7a or the ticket brief
+- **Governing Inputs**:
+  - `AGENTS.md`
+  - `.cursorrules`
+  - accepted ADRs
+  - active ticket brief
+- **Constraints**: all “must not” rules in the ticket brief
+
+### Execution Constraints
+
+You MUST:
+- implement only the active ticket
+- keep changes minimal, localized, reversible, and reviewable
+- follow existing codebase patterns
+- run or identify relevant lint/test/typecheck validation
+- stop if the ticket requires architecture, policy, or execution-authority judgment
+
+You MUST NOT:
+- expand scope beyond the active ticket
+- perform adjacent refactors unless required for tests to pass
+- introduce new dependencies without explicit instruction
+- persist derived or computed financial state unless explicitly authorized
+- imply execution where none exists
+- create new system authority, policy, doctrine, or governance behavior
+- treat informational financial representations as accounting truth
+
+### Output Addendum
+
+Include this section in the normal Implementer output:
+
+```md
+Active Ticket Execution:
+- Source of active ticket:
+- Scope followed:
+- Files changed:
+- Scope expansions: none / <list>
+- Doctrine-sensitive surfaces touched:
+- Validation performed:
+```
+
+
 ---
 
 ## Execution Process

--- a/docs/agents/skills/codex-repo-steward.md
+++ b/docs/agents/skills/codex-repo-steward.md
@@ -65,6 +65,126 @@ You MUST NOT:
 If conflict is detected:
 → STOP and surface explicitly
 
+
+---
+
+## Hedgr Usage Pattern: Activate Active Ticket
+
+Use this pattern only after the Founder has selected **one** candidate ticket.
+
+### Purpose
+
+Move a Founder-approved candidate into repo-native execution truth without implementing product behavior.
+
+### Required Inputs
+
+- **Selected Ticket**: exact ticket text approved by the Founder
+- **Scope**:
+  - `docs/ops/HEDGR_STATUS.md`
+  - any directly referenced sprint, ADR, or ops docs
+- **Objective**: activate the selected ticket as the single approved next ticket
+- **Governing Inputs**:
+  - `AGENTS.md`
+  - `.cursorrules`
+  - accepted ADRs
+  - existing `docs/ops/HEDGR_STATUS.md` conventions
+
+### Actions
+
+- Update `docs/ops/HEDGR_STATUS.md` §7 to name the approved active ticket
+- Populate §7a with the execution brief
+- Remove any “no active ticket” contradiction
+- Preserve all prior completed ticket history
+- Preserve existing section structure and formatting conventions
+
+### Constraints
+
+You MUST:
+- keep the update minimal and auditable
+- treat this as documentation/state activation only
+- surface ambiguity before mutation if the selected ticket is underspecified
+
+You MUST NOT:
+- implement code
+- modify product behavior
+- widen ticket scope
+- introduce new policy, doctrine, or execution authority
+- select the ticket yourself
+- activate more than one ticket
+
+### Output Addendum
+
+Include this section in the normal Repo Steward output:
+
+```md
+Activation Readout:
+- Active ticket:
+- Sections changed:
+- Scope preserved: <yes/no>
+- Implementation performed: no
+- Ambiguities surfaced:
+```
+
+---
+
+## Hedgr Usage Pattern: Closeout Active Ticket
+
+Use this pattern after implementation has been reviewed and the Founder wants to restore clean repo state.
+
+### Purpose
+
+Close the active ticket, reconcile status documentation, and preserve repo truth without introducing the next ticket.
+
+### Required Inputs
+
+- **Scope**:
+  - merged implementation diff or commit(s)
+  - `docs/ops/HEDGR_STATUS.md`
+  - relevant ADRs or ticket brief
+- **Objective**: close out the active ticket and restore no-active-ticket state
+- **Governing Inputs**:
+  - `AGENTS.md`
+  - `.cursorrules`
+  - accepted ADRs
+  - existing closeout patterns in `docs/ops/HEDGR_STATUS.md`
+
+### Actions
+
+- Move the active ticket to the completed list in §7
+- Add or update merged-truth entry in §6, following existing conventions
+- Archive or preserve §7a execution brief according to prior pattern
+- Restore explicit “no active ticket” state
+- Do NOT introduce a new next ticket
+
+### Constraints
+
+You MUST:
+- preserve traceability between ticket, implementation, and status doc
+- keep updates documentation-only unless explicitly instructed otherwise
+- surface discrepancies between implementation and ticket scope
+
+You MUST NOT:
+- implement product changes
+- approve the implementation
+- select the next ticket
+- rewrite history
+- introduce new doctrine, policy, or interpretation
+
+### Output Addendum
+
+Include this section in the normal Repo Steward output:
+
+```md
+Closeout Readout:
+- Closed ticket:
+- Completed-history updated: <yes/no>
+- Merged-truth updated: <yes/no>
+- Active-ticket state restored: <yes/no>
+- New ticket introduced: no
+- Discrepancies surfaced:
+```
+
+
 ---
 
 ## Stewardship Lenses

--- a/docs/agents/skills/codex-synthesizer.md
+++ b/docs/agents/skills/codex-synthesizer.md
@@ -63,6 +63,63 @@ You MUST NOT:
 If conflict is detected:
 → surface it explicitly
 
+
+---
+
+## Hedgr Usage Pattern: Propose New Ticket
+
+Use this pattern when the Founder wants Codex to perform a **proposal pass only** after or alongside Cursor exploration.
+
+### Purpose
+
+Generate a bounded candidate slate for the Founder to review. This pattern does **not** approve, activate, or execute work.
+
+### Required Inputs
+
+- **Artifact Set**:
+  - `docs/ops/HEDGR_STATUS.md`
+  - `AGENTS.md`
+  - relevant ADRs or active sprint docs
+  - optional Cursor exploration output or `/propose-new-ticket` result
+- **Objective**: produce 1–3 plausible next-ticket candidates
+- **Scope**: current active lane only, unless the Founder explicitly widens the review
+- **Governing Inputs**: repo-native authority only
+
+### Operating Constraints
+
+You MUST:
+- remain READ_ONLY
+- produce candidates only
+- distinguish explicit repo truth from interpretation
+- flag doctrine, authority, UX, or execution-class risks
+- mark any recommended candidate as **non-binding**
+
+You MUST NOT:
+- choose the active ticket
+- update `HEDGR_STATUS.md`
+- activate a ticket
+- implement code
+- create new policy, doctrine, or execution authority
+- infer approval from prior conversation or memory
+
+### Output Addendum
+
+Include this section in the normal Synthesizer output:
+
+```md
+Candidate Tickets:
+1. <ticket id/title>
+   - Why plausible:
+   - Scope:
+   - Acceptance sketch:
+   - Risks / doctrine considerations:
+
+Recommended Safest Candidate (Non-Binding):
+- <candidate>
+- Rationale:
+```
+
+
 ---
 
 ## Synthesis Lenses

--- a/docs/agents/skills/codex-verifier.md
+++ b/docs/agents/skills/codex-verifier.md
@@ -66,6 +66,64 @@ You MUST NOT:
 If conflict is detected:
 → STOP and surface explicitly
 
+
+---
+
+## Hedgr Usage Pattern: Verify Active Ticket Implementation
+
+Use this pattern after Codex, Cursor, or a human has produced an implementation for the active ticket.
+
+### Purpose
+
+Perform a bounded read-only verification pass against the active ticket, acceptance criteria, doctrine, ADRs, and repo authority.
+
+### Required Inputs
+
+- **Artifact Under Review**:
+  - implementation diff, branch, PR, or changed files
+- **Review Question**: whether the implementation satisfies the active ticket without drift
+- **Scope**:
+  - active ticket from `docs/ops/HEDGR_STATUS.md` §7 / §7a
+  - changed files only, unless explicitly widened
+- **Governing Inputs**:
+  - `AGENTS.md`
+  - `.cursorrules`
+  - accepted ADRs
+  - relevant doctrine docs
+  - active ticket brief
+- **Constraints**: any ticket-specific “must not” rules
+
+### Verification Constraints
+
+You MUST:
+- remain READ_ONLY
+- assess acceptance alignment and scope discipline
+- identify doctrine-sensitive risks, especially trust-surface overclaim or implied execution
+- distinguish blocking issues from non-blocking notes
+- surface conflicts explicitly
+
+You MUST NOT:
+- modify files
+- approve the implementation as final authority
+- fix issues during verification
+- widen review beyond the declared diff unless explicitly instructed
+- infer acceptance from passing tests alone
+
+### Output Addendum
+
+Include this section in the normal Verifier output:
+
+```md
+Ticket Verification:
+- Active ticket reviewed:
+- Acceptance criteria status:
+- Scope discipline:
+- Doctrine / trust-surface risks:
+- Blocking issues:
+- Non-blocking notes:
+```
+
+
 ---
 
 ## Verification Lenses

--- a/docs/ops/HEDGR_STATUS.md
+++ b/docs/ops/HEDGR_STATUS.md
@@ -359,6 +359,28 @@ Implementation posture preserved:
 - **documentation-only** merge; **no** `apps/`, **no** `packages/`, **no** test file edits, **no** CI workflow edits, **no** runtime or product-copy changes
 - no ADR under ticket intent; merged PR **#125**
 
+### MC-S3-012 - Retail UI money-first shell prototype-only bounded spike
+
+Merged files:
+
+- `apps/frontend/app/prototype/retail-dashboard/RetailDashboardPrototype.tsx`
+- `apps/frontend/app/prototype/retail-dashboard/mock-data.ts`
+- `docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`
+- `docs/ops/HEDGR_STATUS.md`
+
+Implementation truth:
+
+- prototype-route-only presentation spike added `Variant MS - Money-first shell` as the governed direction and default prototype tab under `apps/frontend/app/prototype/retail-dashboard/**`
+- `RetailDashboardPrototype.tsx` added `BalanceLedHero`, `SubordinateAllocation`, and `MoneyFirstShellStack`, preserving existing Control / Variant A / Variant B stacks and prior critique evidence
+- `mock-data.ts` added only `stability.supportLine = 'Protected · Accessible'`; no existing mock fields changed
+- governed readout records the spike pass verdict, unresolved tensions, and explicit non-authorization of any shipped-route edit
+
+Implementation posture preserved:
+
+- **presentation-only**, **prototype-route-only** merge; **no** shipped `(app)/dashboard/**`, **no** `apps/frontend/lib/engine/**`, **no** backend, **no** `packages/ui/**`, **no** copy-module edits, and **no** regression-contract test changes
+- no new `EnginePosture` values, trust states, IA restructuring, APY / earn emphasis, accounting-truth implication, live-operational implication, or shipped-route authorization
+- no ADR under ticket intent; merged PR **#129**
+
 ### MC-S3-013 - Canonical engine type export contract (test-only)
 
 Merged files:
@@ -790,9 +812,10 @@ Completed and merged:
 - `MC-S3-009` - Regression resistance tranche 5 for shipped Stability Engine trust surfaces (test-only; merged PR **#121**; completed record **§40**)
 - `MC-S3-010` - Stability Engine retail UI governance read-path alignment (documentation only; merged PR **#123**; completed record **§41**)
 - `MC-S3-011` - Stability Engine trust-surface coverage matrix (documentation only; merged PR **#125**; completed record **§42**)
-- `MC-S3-012` - Retail UI money-first shell prototype-only bounded spike (presentation-only, prototype-route scope; merged PR **pending**; completed record **§43**; readout artifact **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**)
+- `MC-S3-012` - Retail UI money-first shell prototype-only bounded spike (presentation-only, prototype-route scope; merged PR **#129**; completed record **§43**; readout artifact **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**)
 - `UI-SRA-001` - Shipped retail dashboard adaptation to settled money-first reference surface (bounded `app/(app)/dashboard/**` presentation-only; merged PR **#132**; completed record **§44**; readout **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_READOUT.md`**)
 - `MC-S3-013` - Canonical engine type export contract (test-only; merged PR **#134**; completed record **§45**)
+- `MC-S3-014` - MC-S3-012 merged-truth reconciliation (`HEDGR_STATUS.md` documentation/governance only; completed record **§46**)
 
 Current active ticket status:
 
@@ -807,7 +830,7 @@ Current active ticket status:
 - Cursor must not continue automatically into work beyond what is explicitly defined in this file for an active ticket.
 - Cursor must not drift beyond explicitly defined scope.
 
-**Last completed ticket (summary):** `MC-S3-013` — Canonical engine type export contract (test-only; dedicated `apps/frontend/__tests__/engine-types-contract.test.ts`; `MC-S2-001` matrix row moved to **Covered**; no `EngineState` semantics, posture states, execution wording, accounting wording, backend binding, or live-network behavior); merged PR **#134**; completed record in **§45**.
+**Last completed ticket (summary):** `MC-S3-014` — MC-S3-012 merged-truth reconciliation (`HEDGR_STATUS.md` documentation/governance only; added **§6** merged-truth subsection for `MC-S3-012`, replaced stale PR placeholder language with PR **#129**, converted the **§43** pre-merge note into historical post-merge reconciliation language, and restored **§7** / **§7a** to no-active-ticket state); completed record in **§46**.
 
 ---
 
@@ -819,11 +842,13 @@ When governance approves the next ticket, **§7** will name it and this section 
 
 ---
 
+**Archived brief (MC-S3-014):** MC-S3-012 merged-truth reconciliation — **documentation/governance only**; scope held to `docs/ops/HEDGR_STATUS.md`; added **§6** merged-truth subsection for `MC-S3-012` with prototype-route-only and presentation-only boundaries; replaced stale `MC-S3-012` PR placeholder language with merged PR **#129** across **§7**, **§7a**, continuity, **§41** follow-up, and **§43**; converted **§43** pre-merge closeout posture into historical post-merge reconciliation language; preserved explicit rule that `MC-S3-012` prototype success does **not** authorize shipped-route work. **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** CI, **no** tests, **no** backend, **no** `apps/frontend/lib/engine/**`, **no** shipped `(app)/dashboard/**`, **no** ADR. Completed record: **§46**.
+
 **Archived brief (MC-S3-013):** Canonical engine type export contract — **test-only**; added **`apps/frontend/__tests__/engine-types-contract.test.ts`** to lock canonical `EnginePosture` union, required `EngineState` keys, optional `notice`, and `EngineNotice` title/body shape; updated **`docs/ops/HEDGR_STABILITY_ENGINE_TRUST_SURFACE_TEST_COVERAGE_MATRIX.md`** `MC-S2-001` row from **Partially covered** to **Covered**. **No** `apps/frontend/lib/engine/types.ts` semantics change, **no** new posture values or trust states, **no** execution/accounting wording, **no** `mock.ts`, **no** `useEngineState`, **no** dashboard components, **no** withdraw/tx/market seams, **no** backend, **no** live network. `MC-S3-004` notice/mock contract behavior preserved in intent. No ADR under ticket intent. Merged PR **#134**. Completed record: **§45**.
 
 **Archived brief (UI-SRA-001):** Shipped retail dashboard **structural alignment** to settled money-first reference — **presentation-only**; touched **`apps/frontend/app/(app)/dashboard/page.tsx`**, **`EnginePostureHeader.tsx`**, **`EngineAllocationBands.tsx`**, **`apps/frontend/tests-e2e/smoke-pack.spec.ts`**; **no** `apps/frontend/lib/engine/**`, **no** `layout.client.tsx`, **no** backend. Execution readout **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_READOUT.md`**. Support artifacts **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_EXECUTION_REQUEST.md`**, **`docs/ops/HEDGR_RETAIL_UI_SHIPPED_ROUTE_ADAPTATION_STATUS_PATCH_PROPOSAL.md`**. Merged PR **#132**. Completed record: **§44**. Governance lineage note in readout **§2** and **§7** reconciliation bullet above.
 
-**Archived brief (MC-S3-012):** Retail UI money-first shell **prototype-only** bounded spike — **presentation-only**; scope held to `apps/frontend/app/prototype/retail-dashboard/**` (RetailDashboardPrototype.tsx added `Variant MS — Money-first shell` stack: `BalanceLedHero`, `SubordinateAllocation`, `MoneyFirstShellStack`; mock-data.ts added additive `stability.supportLine`); governance edits to **§7** / **§7a** of this file. **No** shipped `(app)/dashboard/**`, **no** `apps/frontend/lib/engine/**`, **no** `apps/backend/**`, **no** `packages/ui/**`, **no** copy-module or Vitest regression-contract edits from the `MC-S3-004` / `-006` / `-007` / `-008` / `-009` tranche. Reversibility preserved. Governed readout artifact **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`** records the spike's pass verdict and unresolved tensions. No ADR under ticket intent. Merged PR **pending** (number to be populated on merge). Completed record: **§43**.
+**Archived brief (MC-S3-012):** Retail UI money-first shell **prototype-only** bounded spike — **presentation-only**; scope held to `apps/frontend/app/prototype/retail-dashboard/**` (RetailDashboardPrototype.tsx added `Variant MS — Money-first shell` stack: `BalanceLedHero`, `SubordinateAllocation`, `MoneyFirstShellStack`; mock-data.ts added additive `stability.supportLine`); governance edits to **§7** / **§7a** of this file. **No** shipped `(app)/dashboard/**`, **no** `apps/frontend/lib/engine/**`, **no** `apps/backend/**`, **no** `packages/ui/**`, **no** copy-module or Vitest regression-contract edits from the `MC-S3-004` / `-006` / `-007` / `-008` / `-009` tranche. Reversibility preserved. Governed readout artifact **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`** records the spike's pass verdict and unresolved tensions. No ADR under ticket intent. Merged PR **#129**. Completed record: **§43**.
 
 **Archived brief (MC-S3-011):** Stability Engine trust-surface **coverage matrix** — **documentation only**; artifact **`docs/ops/HEDGR_STABILITY_ENGINE_TRUST_SURFACE_TEST_COVERAGE_MATRIX.md`** maps **§6**-grounded shipped Stability Engine surfaces to **existing** Vitest evidence (covered / partially covered / uncovered); governance-evidence disclaimer; withdraw/tx/market **§6** rows omitted from matrix scope by default per artifact; **no** `apps/`, **no** `packages/`, **no** tests or CI; no ADR under ticket intent. Merged PR **#125**. Completed record: **§42**.
 
@@ -863,7 +888,8 @@ When governance approves the next ticket, **§7** will name it and this section 
 - **Regression resistance tranche 5 (test-only, completed):** `MC-S3-009` — **§40** (completed ticket record); merged PR **#121**.
 - **Retail UI governance read-path alignment (documentation-only, completed):** `MC-S3-010` — **§41** (completed ticket record); merged PR **#123**.
 - **Trust-surface coverage matrix (documentation-only, completed):** `MC-S3-011` — **§42** (completed ticket record); merged PR **#125**.
-- **Retail UI money-first shell prototype spike (presentation-only, prototype-route, completed):** `MC-S3-012` — **§43** (completed ticket record); governed readout **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**; merged PR **pending** (to be populated on merge).
+- **Retail UI money-first shell prototype spike (presentation-only, prototype-route, completed):** `MC-S3-012` — **§43** (completed ticket record); governed readout **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**; merged PR **#129**.
+- **MC-S3-012 merged-truth reconciliation (documentation/governance-only, completed):** `MC-S3-014` — **§46** (completed ticket record).
 - **Merged implementation truth:** **§6** remains canonical for shipped code boundaries.
 - When a successor ticket is approved, record it in **§7** and restore the execution brief in **§7a** per governance discipline.
 - Do not infer continuation work from *Proposed* ADRs or roadmap narrative unless **§7** names a ticket.
@@ -1744,7 +1770,7 @@ No ADR or doctrine change under ticket intent. Merged PR **#121**.
 
 **§7** / **§7a** record completion per governance; the **live** approved next ticket is whatever **§7** names (brief in **§7a**) — do not treat this completed-record footer as current sequencing authority.
 
-**Follow-ups:** Successor **`MC-S3-012`** completed — **§43** (retail UI money-first shell prototype-only bounded spike; presentation-only; governed readout **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**; merged PR **pending**); any successor after that appears only when **§7** is updated explicitly.
+**Follow-ups:** Successor **`MC-S3-012`** completed — **§43** (retail UI money-first shell prototype-only bounded spike; presentation-only; governed readout **`docs/ops/HEDGR_RETAIL_UI_IMPLEMENTATION_SPIKE_READOUT.md`**; merged PR **#129**); successor **`MC-S3-014`** completed — **§46** (MC-S3-012 merged-truth reconciliation, documentation/governance only). Any successor after that appears only when **§7** is updated explicitly.
 
 ---
 
@@ -1762,11 +1788,11 @@ No ADR or doctrine change under ticket intent. Merged PR **#121**.
 
 **Scope discipline held.** **No** shipped `(app)/dashboard/**`, **no** `apps/frontend/lib/engine/**`, **no** `apps/backend/**`, **no** `packages/ui/**`, **no** copy-module edits; **no** `MC-S3-004` / `-006` / `-007` / `-008` / `-009` regression-contract test changes in intent; **no** new `EnginePosture` values, trust states, or IA restructuring; **no** APY, earn, chart-adjacent, or instrument-like treatment; **no** ADR under ticket intent.
 
-**Validation.** `pnpm --filter @hedgr/frontend typecheck` clean; `pnpm --filter @hedgr/frontend lint` clean; 58 Vitest files / 713 tests pass. Merged PR **pending** (number to be populated on merge).
+**Validation.** `pnpm --filter @hedgr/frontend typecheck` clean; `pnpm --filter @hedgr/frontend lint` clean; 58 Vitest files / 713 tests pass. Merged PR **#129**.
 
-### Pre-merge closeout posture
+### Post-merge reconciliation
 
-This **§43** record is written in the same working-tree change-set as the implementation and readout. Consistent with governance precedent, the PR number field above is recorded as **pending** and must be patched in on merge. Until the PR merges, **§6** is **not** extended with a `MC-S3-012` subsection; **§6** is the merged-implementation-truth surface and must not carry pre-merge claims. On merge, a follow-up edit should (a) populate every `merged PR **pending**` reference in **§7**, **§7a**, this **§43**, and the continuity block with the actual PR number, and (b) optionally add a **§6** subsection for **`MC-S3-012`** describing the prototype-route code change in merged-truth language.
+This **§43** record was originally written in the same working-tree change-set as the implementation and readout, before PR **#129** was merged. `MC-S3-014` reconciled that historical pre-merge posture after merge by recording PR **#129** in the completed-ticket surfaces and adding the **§6** `MC-S3-012` merged-truth subsection. The pre-merge instruction to omit `MC-S3-012` from **§6** is superseded.
 
 ### Sequencing note
 
@@ -1818,6 +1844,31 @@ This **§43** record is written in the same working-tree change-set as the imple
 **Scope discipline held.** **No** `EngineState` semantics changed, **no** new `EnginePosture` values or trust states, **no** execution/accounting wording, **no** `apps/frontend/lib/engine/mock.ts`, **no** `useEngineState`, **no** dashboard components, **no** withdraw/tx/market seams, **no** backend, **no** live network behavior. **`MC-S3-004`** notice/mock contract behavior preserved in intent.
 
 **Validation.** `pnpm -w test` and `pnpm run validate` completed cleanly in the implementation workspace. Merged PR **#134**.
+
+### Sequencing note
+
+**§7** / **§7a** record completion per governance; the **live** approved next ticket is whatever **§7** names (brief in **§7a**) — do not treat this completed-record footer as current sequencing authority.
+
+**Follow-ups:** Any successor appears only when **§7** is updated explicitly.
+
+---
+
+## 46. Completed execution ticket - MC-S3-014 (MC-S3-012 merged-truth reconciliation)
+
+**Ticket:** `MC-S3-014` — MC-S3-012 merged-truth reconciliation (`HEDGR_STATUS.md`)
+
+**Suggested branch:** `docs/mc-s3-014-mc-s3-012-pr129-status-reconciliation`
+
+### Outcome (documentation/governance only)
+
+- **`docs/ops/HEDGR_STATUS.md` §6** — added a bounded `MC-S3-012` merged-truth subsection for the retail UI money-first shell prototype spike; scope remains prototype-route only and presentation-only
+- **`docs/ops/HEDGR_STATUS.md` §7 / §7a / continuity / §41 / §43** — replaced stale `MC-S3-012` PR placeholder language with merged PR **#129**
+- **`docs/ops/HEDGR_STATUS.md` §43** — converted obsolete pre-merge closeout posture into historical post-merge reconciliation language and recorded that the prior instruction to omit `MC-S3-012` from **§6** is superseded
+- **`docs/ops/HEDGR_STATUS.md`** — restored **§7** / **§7a** to no-active-ticket state and archived this brief
+
+**Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** CI, **no** tests, **no** backend, **no** `apps/frontend/lib/engine/**`, **no** shipped `(app)/dashboard/**`, **no** ADR. `MC-S3-012` prototype evidence still does **not** authorize shipped-route work.
+
+**Validation.** Documentation consistency search clean for stale `MC-S3-012` pending-PR living guidance; `git diff --check -- docs/ops/HEDGR_STATUS.md` clean.
 
 ### Sequencing note
 


### PR DESCRIPTION
# PR: docs(ops): reconcile MC-S3-012 status truth

> Agent-assisted PR prepared from the runbook workflow.

## 1) Summary

This PR reconciles the stale `MC-S3-012` status truth in `docs/ops/HEDGR_STATUS.md` after the bounded retail UI prototype spike merged as PR #129.

It also includes the committed `docs/agents/skills/*` workflow-pattern documentation updates that were explicitly approved for commit.

## 2) Scope

- `docs/ops/HEDGR_STATUS.md`
  - Adds the `MC-S3-012` merged-truth subsection under §6.
  - Replaces stale `merged PR **pending**` references with PR #129.
  - Converts §43 from pre-merge closeout posture to historical post-merge reconciliation.
  - Adds completed ticket record §46 for `MC-S3-014`.
  - Restores §7 / §7a to no-active-ticket state.
- `docs/agents/skills/codex-implementer.md`
- `docs/agents/skills/codex-repo-steward.md`
- `docs/agents/skills/codex-synthesizer.md`
- `docs/agents/skills/codex-verifier.md`
  - Adds active-ticket workflow usage patterns for future bounded agent operation.

## 3) Evidence pack

- Local commits:
  - `5e8f136` `docs(ops): reconcile mc-s3-012 status truth`
  - `12a4bf6` `docs(agents): add active ticket workflow patterns`
- Git evidence for MC-S3-012 merge: `a1ed97b feat(mc-s3-012): bounded retail UI prototype spike and ops readout (#129)`

## 4) Acceptance Criteria

- [x] `MC-S3-012` stale pending-PR language is replaced with PR #129.
- [x] `MC-S3-012` has a bounded §6 merged-truth subsection.
- [x] §43 no longer presents pre-merge guidance as living repo truth.
- [x] `MC-S3-014` is closed in §46 and §7 / §7a return to no active ticket.
- [x] No product/runtime/app/backend/engine code is changed.
- [x] Prototype-route success remains explicitly non-authorizing for shipped-route work.

## 5) Validation

Local checks run:

- [x] `git diff --check`
- [x] Scoped search confirmed no stale `merged PR **pending**`, `Pre-merge closeout posture`, `number to be populated`, or `to be populated on merge` strings remain in `docs/ops/HEDGR_STATUS.md`.

Not run locally:

- [ ] `pnpm run validate`
- [ ] `pnpm --filter @hedgr/frontend run e2e:ci`

Reason: docs-only PR; no app, runtime, backend, engine, CI, or test files changed. CI should provide the canonical runbook validation.

## 6) Risk / Rollback

- Area: docs
- Risk: low
- Rollback: single revert of this PR.

## 7) Runbook Labels

Apply:

- `product:approved`
- `qa:approved`
- `area:docs`
- `risk:low`
