### PR TITLE
docs(ops): add Class B pilot eligibility standard

### DIFF
--- a/docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md
+++ b/docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md
@@ -1,0 +1,124 @@
+# HEDGR — Class B Pilot Eligibility Standard
+
+## 1. Status / Authority / Scope
+
+**Status:** Governance standard / documentation-only.
+
+**Authority:** This standard is subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and Hedgr doctrine. If this document conflicts with those sources, the higher-authority source controls and the conflict must be surfaced explicitly.
+
+**Scope:** This document defines criteria for future Class B pilot eligibility only.
+
+This document does **not** authorize implementation, execution, customer funds movement, custody activation, rails activation, ledger mutation, automated execution, or Class C behavior.
+
+## 2. Purpose
+
+This standard answers:
+
+**What must be true before a future manual / limited pilot execution ticket may be proposed for `HEDGR_STATUS.md` §7?**
+
+It does **not** answer:
+
+**Are deposits, withdrawals, custody, or rails approved to build now?**
+
+## 3. Definition of Class B in Hedgr
+
+`docs/doctrine/hedgr-mvp-project-specification.md` §5 defines MVP execution classes as:
+
+- **Class A - Informational only:** educates, discloses, simulates, or displays engine-aligned posture; no fund movement.
+- **Class B - Manual / limited execution:** human-in-the-loop, pilot, or capped flows with explicit operational controls.
+- **Class C - Automated execution:** programmatic movement or commitment of funds subject to policy and engine rules, only when ADRs and ops status explicitly allow.
+
+Hedgr is currently **not** in active Class B implementation mode. Class B eligibility is a precondition for future sequencing discussion, not an execution state.
+
+## 4. Eligibility Is Not Authorization
+
+**A Class B Pilot Eligibility finding means only that a future scoped Class B ticket may be considered for §7 / §7a. It does not itself authorize deposits, withdrawals, custody, rail integration, treasury operations, stablecoin movement, ledger mutation, or customer fund movement.**
+
+- `HEDGR_STATUS.md` §7 remains the only ticket activation surface.
+- `HEDGR_STATUS.md` §7a remains the active execution brief surface.
+- A future Class B implementation ticket must still define scope, exclusions, acceptance criteria, validation, rollback, and evidence.
+
+## 5. Mandatory Eligibility Criteria
+
+| ID | Criterion | Required evidence | Why it matters |
+|----|-----------|-------------------|----------------|
+| B-M1 | Authority gate | `HEDGR_STATUS.md` §7 names only documentation or eligibility-standard work until implementation is separately approved. §7a bounds scope before work begins. No implementation work is inferred from this standard. | Prevents this governance artifact from becoming an execution approval surface. |
+| B-M2 | ADR gate | Required ADRs are identified before any Class B implementation proposal. At minimum, future ADR coverage must be considered for custody model, rails / vendor boundary, execution authority, reconciliation and ledger truth, policy-runtime relationship, trust / disclosure claims, and failure and rollback posture. These ADRs are prerequisites for implementation consideration; this standard does not draft or accept them. | Ensures material authority expansion is reviewed through the repo ADR process before implementation. |
+| B-M3 | Legal / compliance gate | Jurisdictional assumptions are identified. KYC / AML responsibility is identified. Rail permissions and customer eligibility constraints are identified. User disclosures required for pilot execution are listed at a high level. No legal conclusions are invented by this standard. | Prevents operational or UX claims from running ahead of legal and compliance review. |
+| B-M4 | Custody gate | Custody model is identified. Provider role is identified. User asset control and operational responsibility are described. Failure modes are documented. No UI claim may imply custody guarantees beyond approved truth. | Keeps custody truth explicit before customer-money surfaces are proposed. |
+| B-M5 | Rails gate | Deposit and withdrawal rails are classified as sandbox, internal test, manual pilot, limited live pilot, or not approved. Rail readiness distinguishes integration existence from customer-money authorization. No vague "rails live" language is used. | Separates technical integration from authority to move or receive customer money. |
+| B-M6 | Liquidity and withdrawal integrity gate | Withdrawal path assumptions are documented. Liquidity buffer logic or manual control expectation is identified. Failure, delay, and unresolved-path handling are documented. Kill criteria for withdrawal fragility are defined. | Hedgr doctrine treats liquidity and withdrawal integrity as mission-critical: liquidity is mandatory, users must retain reliable access to capital, and any feature that increases withdrawal fragility must be rejected. |
+| B-M7 | UX / trust gate | User-facing surfaces explain where money is, what is happening, how to exit, what is pending, and what is not guaranteed. Copy avoids urgency, yield-first framing, hidden mechanics, and unsupported certainty. | Trust UX requires users to verify product state rather than rely on vague confidence or hidden mechanics. |
+| B-M8 | Ops / reconciliation gate | Manual review flow is defined. Reconciliation owner / process is identified. Audit trail expectations are documented. Failed, delayed, duplicate, and ambiguous transaction handling is described. Support escalation path is identified. | Class B pilots require human controls, auditability, and failure handling before any customer-money workflow is proposed. |
+| B-M9 | Simulation / staging gate | Sandbox, simulation, mock, and staging states are visually and operationally distinct from live execution. No simulated state may be presented as customer-money truth. Existing dev-only simulator boundaries remain preserved. | Preserves ADR 0017 and read-only simulator boundaries so review aids do not become product semantics. |
+| B-M10 | Exclusion gate | Future eligibility review explicitly excludes Class C automation, autonomous reallocation, protocol yield routing, live treasury execution, ledger mutation from engine output, Copilot execution, hidden fund movement, backend execution workers, production rail integration, and customer-money movement unless separately authorized by a future §7 / §7a ticket and required ADR/governance review. | Keeps Class B eligibility from silently approving adjacent execution, automation, or fund-movement authority. |
+
+## 6. Supporting Criteria
+
+The following supporting criteria may be used in a future eligibility evaluation. They are not automatically authorizing:
+
+- Vendor readiness
+- Operational staffing
+- Monitoring and incident response
+- Data retention and audit evidence
+- Pilot caps and exposure limits
+- Customer support readiness
+- Regulatory review status
+- Rollback / kill-switch readiness
+
+## 7. Evidence Table Template
+
+This template is not currently a completed pass assessment. It exists to define the evidence shape required for a future eligibility review.
+
+| Criterion | Pass / Partial / Fail / Not assessed | Evidence pointer | Blocker or note |
+|-----------|--------------------------------------|------------------|-----------------|
+| B-M1 | Not assessed | | |
+| B-M2 | Not assessed | | |
+| B-M3 | Not assessed | | |
+| B-M4 | Not assessed | | |
+| B-M5 | Not assessed | | |
+| B-M6 | Not assessed | | |
+| B-M7 | Not assessed | | |
+| B-M8 | Not assessed | | |
+| B-M9 | Not assessed | | |
+| B-M10 | Not assessed | | |
+
+## 8. Non-Authorization Clauses
+
+This standard does not authorize:
+
+- deposits
+- withdrawals
+- stablecoin conversion
+- custody activation
+- mobile money integration
+- bank integration
+- Circle or vendor integration
+- live FX execution
+- treasury operations
+- yield routing execution
+- policy-runtime binding
+- backend workers
+- ledger mutation
+- customer-facing automation
+- Copilot runtime execution
+- Class C automation
+- customer fund movement
+
+## 9. Relationship to Future Tickets
+
+- A future Class B implementation ticket must be separately named in `HEDGR_STATUS.md` §7.
+- A future Class B implementation ticket must have a bounded §7a brief.
+- The future ticket must cite which eligibility criteria are satisfied, deferred, or blocked.
+- Any material Class B implementation must include ADR review.
+- This standard does not create a backlog, queue order, or default next ticket.
+
+## 10. Closeout Meaning
+
+If this standard is merged, the closeout meaning is only:
+
+**Hedgr now has a repo-native governance standard for assessing future Class B pilot eligibility.**
+
+It does **not** mean:
+
+**Hedgr is Class B ready, approved to execute, or authorized to move customer funds.**

--- a/docs/ops/HEDGR_STATUS.md
+++ b/docs/ops/HEDGR_STATUS.md
@@ -539,6 +539,34 @@ Implementation posture preserved:
 - **documentation-only** governance orientation; **no** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend product or copy edits, **no** CI workflow changes, **no** ADR status or index changes, **no** successor ticket named by the readout
 - no ADR under ticket intent
 
+### GOV-B-001 - Class B Pilot Eligibility Standard (documentation-only)
+
+Merged files:
+
+- `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`
+- `docs/ops/HEDGR_STATUS.md`
+
+Implementation truth:
+
+- governance-only standard added at `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`
+- defines mandatory and supporting criteria for future Class B pilot eligibility assessment
+- clarifies that eligibility means eligible for future `§7` / `§7a` consideration only
+- does not authorize implementation, execution, custody, rails, deposits, withdrawals, ledger mutation, stablecoin movement, treasury operations, Copilot execution, or customer fund movement
+
+Implementation posture preserved:
+
+- documentation-only governance artifact
+- no `apps/`
+- no `packages/`
+- no `scripts/`
+- no `.github/`
+- no backend
+- no frontend implementation
+- no tests
+- no CI workflow changes
+- no ADR status changes
+- no successor implementation ticket
+
 ### MC-S2-004 - Allocation bands UI
 
 Implementation truth:
@@ -1028,6 +1056,7 @@ Completed and merged:
 - `MC-S3-019` - Playwright smoke coverage extension for shipped Stability Engine trust surfaces (test-only; merged PR **#148**; completed record **§51**)
 - `COP-GOV-001` - Copilot MVP advisory lane definition (documentation-only governance artifact; completed record **§52**)
 - `MC-S3-020` - MVP phased alignment (documentation-only governance readout; merged PR **#152**; completed record **§53**)
+- `GOV-B-001` - Class B Pilot Eligibility Standard (documentation-only governance standard; completed record **§54**)
 
 Current active ticket status:
 
@@ -1042,7 +1071,7 @@ Current active ticket status:
 - Cursor must not continue automatically into work beyond what is explicitly defined in this file for an active ticket.
 - Cursor must not drift beyond explicitly defined scope.
 
-**Last completed ticket (summary):** `MC-S3-020` — MVP phased alignment (documentation-only governance readout mapping MVP spec **§5** / **§9** / **§12** and whitepaper North Star to **§2** / **§6a–§6c** repo posture; subordinate readout at **`docs/ops/HEDGR_MVP_PHASE_ALIGNMENT.md`**; merged **PR #152**; **§7** / **§7a** restored to no-active-ticket state); completed record in **§53**.
+**Last completed ticket (summary):** `GOV-B-001` — Class B Pilot Eligibility Standard (documentation-only governance standard defining minimum authority, ADR, legal/compliance, custody, rails, liquidity, UX/trust, ops/reconciliation, simulation/staging, and exclusion gates for future Class B pilot eligibility assessment; subordinate artifact at **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`**; **§7** / **§7a** restored to no-active-ticket state; no approved Class B implementation ticket created); completed record in **§54**.
 
 ---
 
@@ -1053,6 +1082,8 @@ Current active ticket status:
 When governance approves the next ticket, **§7** will name it and this section will hold the full execution brief until closeout.
 
 ---
+
+**Archived brief (GOV-B-001):** Class B Pilot Eligibility Standard — **documentation-only governance standard**; scope held to **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`** and **`docs/ops/HEDGR_STATUS.md`**. Created the repo-native standard for assessing future Class B pilot eligibility before any manual / limited execution ticket involving deposits, withdrawals, custody, rails, reconciliation, or treasury operations may be proposed for **§7**. The standard defines mandatory criteria **B-M1** through **B-M10**, supporting criteria, a future evidence-table template, explicit non-authorization clauses, and future-ticket requirements. Eligibility means eligible for future **§7** / **§7a** consideration only. **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or copy changes, **no** CI workflow changes, **no** ADR status changes, **no** successor ticket, **no** Class B implementation approval, and **no** deposits, withdrawals, custody, rails, ledger mutation, stablecoin movement, treasury operations, Copilot execution, or customer fund movement authority. Completed record: **§54**.
 
 **Archived brief (MC-S3-020):** MVP phased alignment — **documentation-only**; scope held to **`docs/ops/HEDGR_MVP_PHASE_ALIGNMENT.md`** and **`docs/ops/HEDGR_STATUS.md`**. Published readout mapping **`docs/doctrine/hedgr-mvp-project-specification.md`** **§5** (execution classes **A** / **B** / **C**), **§9** (governance-gated phases), and **§12** (success criteria), plus **`docs/doctrine/hedgr-whitepaper.md`** North Star framing, to **§2** / **§6a–§6c** repo posture so “MVP completion” is read as **phase-gated**, not as Class **B**/**C** execution readiness. Readout subordinates to **`HEDGR_STATUS.md` §7** / **§7a** and does **not** sequence work; **§3** item **9** is discoverability only. **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or copy changes, **no** CI workflow changes, **no** ADR status or index changes, **no** successor ticket. Merged PR **#152**. Completed record: **§53**.
 
@@ -2269,6 +2300,29 @@ This **§43** record was originally written in the same working-tree change-set 
 **Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or product copy edits, **no** CI workflow changes, **no** ADR status or index changes, **no** successor ticket, and **no** widening of execution, ledger, policy-runtime, custody, vendor, Circle, stablecoin, or live-service authority.
 
 **Validation.** Readout acceptance shape verified against **§7a** brief (subordination language; **§9** vs repo posture; **§12** vs read-only / informational constraints); `git diff --check -- docs/ops/HEDGR_STATUS.md` clean. No tests were run because the ticket scope explicitly excludes tests and product/runtime files.
+
+### Sequencing note
+
+**§7** / **§7a** record completion per governance; the **live** approved next ticket is whatever **§7** names (brief in **§7a**) — do not treat this completed-record footer as current sequencing authority.
+
+**Follow-ups:** Any successor appears only when **§7** is updated explicitly.
+
+---
+
+## 54. Completed execution ticket - GOV-B-001 (Class B Pilot Eligibility Standard)
+
+**Ticket:** `GOV-B-001` — Class B Pilot Eligibility Standard (documentation-only governance standard)
+
+### Outcome (documentation-only)
+
+- **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`** — added the repo-native governance standard defining minimum criteria before any future manual / limited Class B pilot execution ticket may be proposed for **§7**
+- **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`** — defined mandatory criteria **B-M1** through **B-M10** covering authority, ADR, legal/compliance, custody, rails, liquidity and withdrawal integrity, UX/trust, ops/reconciliation, simulation/staging, and exclusions
+- **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`** — added supporting criteria, a future evidence-table template, explicit non-authorization clauses, relationship-to-future-ticket rules, and closeout meaning
+- **`docs/ops/HEDGR_STATUS.md`** — added §6 merged-truth subsection `GOV-B-001`; §7 completed list extended with `GOV-B-001`; §7 / §7a restored to no active ticket; §7a archived brief for `GOV-B-001`; §54 (this record)
+
+**Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or product copy edits, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, and **no** Class B approval. This closeout does **not** authorize deposits, withdrawals, custody activation, rails integration, ledger mutation, stablecoin movement, treasury operations, Copilot execution, backend workers, production rail integration, Class C automation, or customer fund movement.
+
+**Validation.** Documentation-only diff review, `git diff --check -- docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md docs/ops/HEDGR_STATUS.md`, scoped artifact review, and `git status --short` completed locally. No tests were run because the ticket scope explicitly excludes tests and product/runtime files.
 
 ### Sequencing note
 


### PR DESCRIPTION
## Summary
- Add `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md` as the repo-native governance standard for future Class B pilot eligibility assessment.
- Update `docs/ops/HEDGR_STATUS.md` with the minimal GOV-B-001 merged-truth, completed-sequence, archived-brief, and closeout records.
- Preserve the rule that eligibility is only eligible for future `§7` / `§7a` consideration, not authorization.

## Scope
- Documentation-only governance standard.
- No implementation code, tests, workflows, backend, frontend, packages, scripts, or ADR status changes.
- No approved Class B implementation ticket created by this work.

## Acceptance Criteria
- [x] `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md` exists.
- [x] The artifact defines Class B eligibility as governance-only.
- [x] Mandatory criteria `B-M1` through `B-M10` are included.
- [x] A future evidence-table template is included.
- [x] Explicit non-authorization clauses are included.
- [x] Future implementation still requires separate `§7` naming and `§7a` briefing.
- [x] `docs/ops/HEDGR_STATUS.md` references the artifact and records the documentation-only posture.
- [x] No implementation files are changed.
- [x] No tests, workflows, backend, frontend, or package files are changed.
- [x] No ADR is accepted, deprecated, or materially rewritten.
- [x] Closeout states there is no approved Class B implementation ticket created by this work.

## Validation
- [x] `git diff --check -- docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md docs/ops/HEDGR_STATUS.md`
- [x] `pnpm run validate`
- [x] Backend stub on `http://localhost:5050` with `STUB_MODE=true`
- [x] `NEXT_PUBLIC_AUTH_MODE=mock NEXT_PUBLIC_DEFI_MODE=mock NEXT_PUBLIC_FX_MODE=stub NEXT_PUBLIC_MARKET_MODE=manual NEXT_PUBLIC_MARKET_SELECTED=UNKNOWN NEXT_PUBLIC_APP_ENV=dev NEXT_PUBLIC_API_BASE_URL=http://localhost:5050 NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=true pnpm --filter @hedgr/frontend run e2e:ci` — 53 passed

## Runbook Labels
- `product:approved`
- `qa:approved`
- `area:docs`
- `risk:low`