### PR TITLE
docs(ops): add Class B dependency map

### DIFF
--- a/docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md
+++ b/docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md
@@ -1,0 +1,128 @@
+# HEDGR — Class B Artifact Dependency Map
+
+## 1. Status / Authority / Scope
+
+**Status:** Governance dependency map / documentation-only.
+
+**Authority:** Non-authoritative; subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and Hedgr doctrine.
+
+**Scope:** Maps dependency relationships between future Class B prerequisite artifacts identified in `docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`.
+
+**Mode:** Sequencing logic only, not activation.
+
+This dependency map does not authorize implementation, execution, custody, rails, deposits, withdrawals, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement.
+
+## 2. Purpose
+
+This artifact exists to consolidate the Class B governance spine.
+
+It answers:
+
+**Which future Class B prerequisite artifacts should precede, inform, or constrain others before any future Class B implementation proposal may be considered?**
+
+It does not answer:
+
+**Which implementation ticket should be opened next?**
+
+It does not create:
+
+- a backlog
+- a queue order
+- a default next ticket
+- implementation authority
+- ADR acceptance
+- vendor approval
+- legal approval
+- custody approval
+- rail approval
+- pilot approval
+
+## 3. Source inputs
+
+The source inputs for this map are:
+
+- `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`
+- `docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`
+- `docs/ops/HEDGR_MVP_PHASE_ALIGNMENT.md`
+- `docs/ops/HEDGR_STATUS.md`
+- `docs/doctrine/hedgr-mvp-project-specification.md`
+- `docs/doctrine/hedgr-constitutional-charter.md`
+- `docs/doctrine/hedgr-ux-constitution.md`
+- `docs/decisions/SPRINT-2-ADR-INDEX.md`
+
+Inputs are used for dependency mapping only. They do not create new execution authority.
+
+## 4. Artifact classes
+
+| Class | Meaning | Examples | Authority effect |
+|---|---|---|---|
+| Foundation artifact | Defines broad prerequisite context or constraints. | legal / compliance requirements memo; custody boundary memo; rail classification register; liquidity / withdrawal control memo | informs later decisions; does not authorize implementation. |
+| Decision-prep artifact | Narrows options and prepares future ADR consideration. | ADR scoping memo; vendor boundary memo; policy-runtime boundary memo | may prepare ADRs; does not accept ADRs. |
+| Operational artifact | Defines pilot operations, controls, support, reconciliation, and incident handling. | pilot ops runbook; reconciliation SOP; support escalation matrix; audit evidence checklist | documents operating assumptions; does not activate operations. |
+| UX / trust artifact | Defines customer-facing communication, copy, states, failures, and unsupported claims. | Class B trust UX pack; failure-state UX review; deposit / withdrawal pending-state copy review | constrains product surfaces; does not authorize surfaces. |
+| Activation artifact | Only relevant if future governance separately considers implementation. | implementation-specific §7a brief; future scoped Class B ticket; required accepted ADRs | only effective if separately named and approved through repo governance. |
+
+## 5. Dependency map
+
+| Artifact | Class | Depends on | Informs / constrains | Why dependency matters | Current status |
+|---|---|---|---|---|---|
+| Legal / compliance requirements memo | Foundation artifact | `HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`; doctrine / constitutional constraints | custody boundary memo; rail classification register; trust UX pack; pilot ops runbook; ADR scoping memo | Jurisdiction, eligibility, KYC / AML, rail permission, and disclosure constraints shape every future Class B boundary. | Not created. |
+| Custody boundary memo | Foundation artifact | legal / compliance requirements memo; MVP spec custody intent; current non-authorization posture | ADR scoping memo; trust UX pack; pilot ops runbook; reconciliation SOP; implementation-specific §7a brief | Asset-control, provider responsibility, failure modes, and custody guarantees must be known before trust claims or implementation boundaries. | Not created. |
+| Rail classification register | Foundation artifact | legal / compliance requirements memo; custody boundary memo where asset custody or settlement boundaries are implicated; Class B gap register | ADR scoping memo; liquidity / withdrawal control memo; trust UX pack; pilot ops runbook; reconciliation SOP; implementation-specific §7a brief | Sandbox, internal test, manual pilot, limited live pilot, and not-approved rail states must be separated before any rail language can be used safely. | Not created. |
+| Liquidity / withdrawal control memo | Foundation artifact | legal / compliance requirements memo; custody boundary memo; rail classification register; constitutional liquidity constraints | trust UX pack; pilot ops runbook; reconciliation SOP; ADR scoping memo; implementation-specific §7a brief | Withdrawal reliability, unresolved-path handling, liquidity buffers, and kill criteria must exist before a pilot can make customer-money claims. | Not created. |
+| ADR scoping memo | Decision-prep artifact | legal / compliance requirements memo; custody boundary memo; rail classification register; liquidity / withdrawal control memo; gap register | future ADR drafting; future scoped Class B ticket; implementation-specific §7a brief | ADRs should be scoped after prerequisite boundaries are understood, not drafted prematurely. | Not created. |
+| Class B trust UX pack | UX / trust artifact | legal / compliance requirements memo; custody boundary memo; rail classification register; liquidity / withdrawal control memo; UX constitution | future frontend implementation; support scripts; pilot ops runbook; implementation-specific §7a brief | Customer-facing states must not imply unsupported custody, rail, withdrawal, or liquidity guarantees. | Not created. |
+| Pilot ops runbook | Operational artifact | legal / compliance requirements memo; custody boundary memo; rail classification register; liquidity / withdrawal control memo; trust UX pack | reconciliation SOP; support escalation matrix; audit evidence checklist; implementation-specific §7a brief | Manual / limited execution requires owner, controls, cadence, escalation, and fallback logic before activation can be considered. | Not created. |
+| Reconciliation SOP | Operational artifact | custody boundary memo; rail classification register; liquidity / withdrawal control memo; pilot ops runbook | audit evidence checklist; support escalation matrix; implementation-specific §7a brief | Duplicate, delayed, failed, ambiguous, and unresolved transaction states must be operationally reconciled before pilot execution. | Not created. |
+| Support escalation matrix | Operational artifact | trust UX pack; pilot ops runbook; reconciliation SOP | customer support posture; incident response; implementation-specific §7a brief | Failed, delayed, duplicate, and ambiguous customer-money issues need escalation ownership before any pilot. | Not created. |
+| Audit evidence checklist | Operational artifact | pilot ops runbook; reconciliation SOP; support escalation matrix; legal / compliance requirements memo | implementation-specific §7a brief; future post-pilot review | Pilot activity must produce traceable evidence before expanding authority. | Not created. |
+| Staging/live-state separation memo | Foundation artifact | simulation / staging boundary evidence; rail classification register if rails are involved; trust UX pack if customer-facing states are involved | future frontend implementation; CI / E2E posture; implementation-specific §7a brief | Simulated, sandbox, staged, and live customer-money states must remain visually and operationally distinct. | Not created. |
+| Implementation-specific §7a brief | Activation artifact | legal / compliance requirements memo; custody boundary memo; rail classification register; liquidity / withdrawal control memo; ADR scoping memo; trust UX pack; pilot ops runbook; reconciliation SOP; support escalation matrix; audit evidence checklist; staging/live-state separation memo; any required accepted ADRs | only the future scoped implementation ticket it belongs to | Implementation authority must be bounded by concrete prerequisites, not general readiness language. | Not active. |
+
+## 6. Recommended dependency order
+
+| Order | Artifact | Reason | May run in parallel with |
+|---|---|---|---|
+| 1 | Legal / compliance requirements memo | Frames jurisdiction, eligibility, KYC / AML, rail permission, and disclosure assumptions before downstream claims are shaped. | None as a dependency predecessor. |
+| 2 | Custody boundary memo | Defines asset-control, provider responsibility, custody guarantees, and failure boundaries. | Rail classification register only after legal / compliance assumptions are framed. |
+| 3 | Rail classification register | Separates sandbox, internal test, manual pilot, limited live pilot, and not-approved rail states. | Custody boundary memo only after legal / compliance assumptions are framed. |
+| 4 | Liquidity / withdrawal control memo | Establishes withdrawal reliability, liquidity-buffer, unresolved-path, and kill-criteria constraints. | ADR scoping memo discovery notes, if explicitly non-authorizing. |
+| 5 | ADR scoping memo | Narrows future decision records after legal, custody, rail, and liquidity boundaries are known. | Trust UX discovery after custody, rail, and liquidity assumptions are stable enough. |
+| 6 | Class B trust UX pack | Constrains customer-facing claims, states, failures, exits, and unsupported guarantees. | Pilot ops runbook only after custody, rail, and liquidity constraints are known. |
+| 7 | Pilot ops runbook | Defines owner, controls, cadence, escalation, and fallback logic before activation can be considered. | Reconciliation SOP drafting only after the runbook operating assumptions are clear. |
+| 8 | Reconciliation SOP | Defines duplicate, delayed, failed, ambiguous, and unresolved transaction handling. | Support escalation matrix once pilot ops and trust UX constraints are known. |
+| 9 | Support escalation matrix | Assigns escalation ownership for failed, delayed, duplicate, and ambiguous customer-money issues. | Audit evidence checklist once reconciliation expectations are clear. |
+| 10 | Audit evidence checklist | Defines traceable evidence expectations before any authority expansion is considered. | Staging/live-state separation memo if staging or sandbox distinctions are in scope. |
+| 11 | Staging/live-state separation memo | Keeps simulated, sandbox, staged, and live customer-money states distinct. | Audit evidence checklist where staging evidence needs to be captured. |
+| 12 | Implementation-specific §7a brief | Binds any future scoped proposal to concrete prerequisite artifacts and accepted ADRs. | None. This remains last and inactive unless separately authorized. |
+
+Parallelization guidance:
+
+- Custody boundary memo and rail classification register may be drafted in parallel only after legal / compliance assumptions are framed.
+- Trust UX pack may begin once custody, rail, and liquidity assumptions are stable enough to avoid unsupported claims.
+- Pilot ops runbook may begin once custody, rail, liquidity, and trust UX constraints are known.
+- ADR scoping memo should not precede legal, custody, rail, and liquidity framing.
+- Implementation-specific §7a brief must remain last and inactive unless separately authorized.
+
+This order is dependency logic, not a backlog, queue, activation order, or implementation sequence.
+
+## 7. Dependency principles
+
+1. Legal / compliance before claims
+    - No custody, rail, or customer-money claim should be shaped before jurisdiction, eligibility, KYC / AML, permissions, and disclosure assumptions are known.
+2. Custody before trust copy
+    - Users cannot be told where money is or who controls it before custody boundaries are defined.
+3. Rails before transaction promises
+    - Deposit / withdrawal timing, pending states, failure paths, and limits depend on rail classification.
+4. Liquidity before withdrawal confidence
+    - Withdrawal copy and pilot controls must be constrained by liquidity buffers, unresolved-path handling, and kill criteria.
+5. Ops before activation
+    - Manual / limited execution cannot be considered without owners, review flow, reconciliation, support, audit trail, and incident handling.
+6. ADRs after boundary discovery
+    - ADRs should record material decisions once boundaries are known enough to avoid speculative decision records.
+7. §7a last
+    - An implementation-specific execution brief should only exist after prerequisite artifacts and accepted ADRs are ready for a scoped proposal.
+
+## 8. Non-authorization statement
+
+This dependency map is non-authoritative and documentation-only. It does not activate, sequence, approve, or implement Class B execution. Any future Class B implementation work still requires separate HEDGR_STATUS.md §7 naming, a bounded §7a execution brief, and any required accepted ADRs.

--- a/docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md
+++ b/docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md
@@ -1,0 +1,123 @@
+# HEDGR — Class B Eligibility Gap Register
+
+## 1. Status / Authority / Scope
+
+**Status:** Governance evidence register / documentation-only.
+
+**Authority:** Non-authoritative; subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and Hedgr doctrine.
+
+**Scope:** Records current repo-native evidence gaps against `B-M1` through `B-M10` from `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`.
+
+**Mode:** Evidence preservation only.
+
+This register does not authorize implementation, execution, custody, rails, deposits, withdrawals, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement.
+
+## 2. Purpose
+
+This register exists to preserve repo-native memory of the Class B eligibility evidence inventory.
+
+It answers:
+
+**What evidence currently exists, and what gaps remain, against the Class B Pilot Eligibility Standard?**
+
+It does not answer:
+
+**Is Hedgr approved for Class B execution?**
+
+It does not create:
+
+- a backlog
+- a queue order
+- a default next ticket
+- implementation authority
+- ADR acceptance
+- vendor approval
+- legal approval
+- custody approval
+- rail approval
+
+## 3. Source assessment
+
+The current posture recorded here comes from a read-only evidence inventory against `docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`. Because that inventory was read-only, this register summarizes it as repo-memory input, not as authority.
+
+- **Pass:** 3
+- **Partial:** 7
+- **Fail:** 0
+- **Not assessed:** 0
+
+This gap register does not conclude that Hedgr is Class B ready. It preserves the current evidence posture against the Class B Pilot Eligibility Standard.
+
+## 4. Gap Register Table
+
+| Criterion | Current status | Existing evidence posture | Gap / blocker | Future artifact type likely required | Authority note |
+|---|---|---|---|---|---|
+| B-M1 — Authority gate | Pass | `HEDGR_STATUS.md` §7 has no approved next ticket. §7a has no active execution ticket. Current posture blocks implied Class B implementation authority. | No current blocker for authority containment. | Future §7 / §7a only if implementation is separately proposed. | Pass confirms containment only; it does not authorize execution. |
+| B-M2 — ADR gate | Partial | Repo ADR discipline exists. Class B standard identifies future ADR topics. | No accepted Class B ADR set exists for custody, rails/vendor boundary, execution authority, reconciliation / ledger truth, policy-runtime relationship, trust claims, failure, or rollback. | ADR scoping memo, then separate ADRs if implementation boundaries become concrete. | ADR path existence does not authorize implementation. |
+| B-M3 — Legal / compliance gate | Partial | General doctrine references regulatory strategy, KYC / AML, data residency, and trust disclosures. Appendix-style examples say assumptions must be confirmed with counsel. | No concrete jurisdictional assumptions, KYC / AML responsibility, customer eligibility, rail permission, or pilot disclosure evidence. | Legal / compliance requirements memo; jurisdiction-specific review; disclosure checklist. | No legal conclusions may be invented by repo docs. |
+| B-M4 — Custody gate | Partial | MVP spec identifies custodial infrastructure intent, subject to ADR. Current status denies custody activation authority. | No complete custody model, provider responsibility matrix, asset-control model, operational responsibility model, or custody-failure evidence. | Custody boundary memo; provider responsibility matrix; ADR if custody model is selected. | Custody intent is not custody activation. |
+| B-M5 — Rails gate | Partial | MVP spec frames deposits / withdrawals as future Class B or Class C depending on phase and authorization. Current phase alignment separates rail intent from live rail proof. | No rail classification table exists for deposit / withdrawal rails by sandbox, internal test, manual pilot, limited live pilot, or not approved. | Rail classification register; vendor evidence pack; ADR if rail boundary is selected. | Rail mention is not rail approval. |
+| B-M6 — Liquidity and withdrawal integrity gate | Partial | Doctrine treats liquidity and withdrawal access as mission-critical. Existing withdrawal surfaces are read-only / informational. | No Class B withdrawal-path assumptions, liquidity-buffer logic, manual-control model, unresolved-path handling, or kill criteria. | Liquidity / withdrawal control memo; pilot kill-criteria definition; operations runbook. | Withdrawal UX clarity is not withdrawal reliability. |
+| B-M7 — UX / trust gate | Partial | UX doctrine requires users to know where money is, what it is doing, and how to exit. Existing trust surfaces are read-only / informational. | No Class B customer-money UX pack covering deposits, withdrawals, custody, rails, pending states, exits, failures, guarantees, and unsupported claims. | Class B trust UX pack; copy review; failure-state UX review. | UX principles do not authorize execution surfaces. |
+| B-M8 — Ops / reconciliation gate | Partial | Reconciliation visibility exists as read-only / frontend-only baseline. PR template requires money-path risk classification and evidence receipts. | No manual review owner / process, reconciliation operating process, audit trail expectation, duplicate / ambiguous transaction handling, or support escalation path. | Pilot ops runbook; reconciliation SOP; support escalation matrix; audit evidence checklist. | Reconciliation copy is not pilot operations. |
+| B-M9 — Simulation / staging gate | Pass | ADR 0017 and status records maintain dev-only simulator / review seam boundaries. Hermetic CI posture preserves no-live-dependency discipline. | No current blocker for existing simulation boundary. Future Class B staging plan would still be required if implementation is proposed. | Future staging/live-state separation memo if Class B implementation is proposed. | Safe simulation does not authorize live execution. |
+| B-M10 — Exclusion gate | Pass | GOV-B-001 and `HEDGR_STATUS.md` explicitly exclude deposits, withdrawals, custody, rails, treasury, ledger mutation, Copilot runtime execution, Class C automation, and customer fund movement. | No current blocker for exclusion posture. | Future implementation briefs must restate exclusions and identify any explicitly authorized exception. | Exclusion clarity is defensive; it does not create implementation authority. |
+
+## 5. Gap categories
+
+**Authority / sequencing:** Current evidence preserves containment through no active §7 / §7a implementation ticket. Any future implementation posture would require separate explicit sequencing.
+
+**ADR / governance:** Existing ADR discipline is present, but Class B-specific ADR coverage is not accepted for custody, rails/vendor boundary, execution authority, reconciliation / ledger truth, policy-runtime relationship, trust claims, failure, or rollback.
+
+**Legal / compliance:** Doctrine records regulatory and compliance concerns at a general level, but concrete jurisdiction, eligibility, responsibility, permission, and disclosure evidence is absent.
+
+**Custody:** Current doctrine contains custody intent, while current governance blocks custody activation. Provider roles, asset-control responsibilities, operational ownership, and failure evidence remain undefined.
+
+**Rails:** Product doctrine names deposits and withdrawals as future execution-class surfaces, but rail readiness is not classified by sandbox, internal test, manual pilot, limited live pilot, or not-approved state.
+
+**Liquidity / withdrawal integrity:** Liquidity and withdrawal access are doctrine-critical, but Class B withdrawal assumptions, buffer logic, manual controls, unresolved-path handling, and kill criteria remain absent.
+
+**UX / trust:** UX doctrine requires verifiable money-state clarity, but there is no Class B trust UX pack for customer-money states, unsupported claims, guarantees, pending paths, exits, or failures.
+
+**Ops / reconciliation:** Read-only reconciliation visibility exists, but pilot operating ownership, reconciliation procedure, audit expectations, duplicate / ambiguous handling, and support escalation remain undefined.
+
+**Simulation / staging:** Existing simulation boundaries are contained by ADR 0017 and hermetic CI posture. A Class B staging/live-state separation artifact would still be needed if implementation is separately proposed.
+
+**Exclusions / non-authorization:** Current governance explicitly excludes customer-money movement and adjacent authority expansion. This register preserves those exclusions rather than converting them into work approval.
+
+## 6. Future artifact map
+
+| Gap area | Future artifact type | Required before Class B implementation proposal? | Notes |
+|---|---|---|---|
+| ADR / governance | ADR scoping memo | Yes | Would identify which separate ADRs are needed before concrete implementation boundaries are proposed. |
+| Custody | Custody boundary memo | Yes | Would define custody model assumptions, asset-control boundaries, and provider responsibility posture. |
+| Rails | Rail classification register | Yes | Would distinguish sandbox, internal test, manual pilot, limited live pilot, and not-approved rail states. |
+| Legal / compliance | Legal / compliance requirements memo | Yes | Would record jurisdictional, eligibility, KYC / AML, permission, and disclosure assumptions for review. |
+| UX / trust | Class B trust UX pack | Likely | Would cover deposits, withdrawals, custody, rails, pending states, exits, failures, guarantees, and unsupported claims. |
+| Liquidity / withdrawal integrity | Liquidity / withdrawal control memo | Yes | Would define assumptions, controls, unresolved-path handling, and reliability limits. |
+| Ops / reconciliation | Pilot ops runbook | Yes | Would identify manual owners, controls, escalation path, and operating cadence for a pilot. |
+| Ops / reconciliation | Reconciliation SOP | Yes | Would define reconciliation process, audit trail expectations, and exception handling. |
+| Ops / support | Support escalation matrix | Likely | Would identify support ownership and escalation path for failed, delayed, duplicate, or ambiguous transactions. |
+| Simulation / staging | Staging/live-state separation memo | Depends | Required if a future proposal introduces staging, sandbox, or pilot-live distinction. |
+| Authority / sequencing | Implementation-specific §7a brief | Yes | Required only if `HEDGR_STATUS.md` §7 separately names a Class B implementation ticket. |
+
+No item in this table is approved by this register.
+
+## 7. Drift risks
+
+| Term | Possible misread | Guardrail interpretation |
+|---|---|---|
+| readiness | Hedgr is ready for Class B execution. | Evidence posture only; readiness is not approval, sequencing, or execution authority. |
+| pilot | A limited live customer-money flow is approved. | Pilot language remains future and gated unless §7 / §7a separately authorize it. |
+| rails | Deposit or withdrawal integrations are approved or live. | Rails are future or conceptual until classified, reviewed, and separately authorized. |
+| live | Simulated, staged, or read-only surfaces are production money truth. | Live customer-money truth requires explicit execution authority and supporting artifacts. |
+| integration | Vendor or rail integration may proceed from doctrine references. | Integration requires separate vendor, legal, ADR, and §7 / §7a authority where applicable. |
+| wallet | Wallet intent implies custody or fund movement authority. | The wallet is a proof surface in current posture; custody and movement remain gated. |
+| custody | Custodial infrastructure intent authorizes custody activation. | Custody intent is not custody approval; model and responsibilities remain gaps. |
+| withdrawal | Existing withdrawal UX proves withdrawal reliability. | Current withdrawal surfaces are read-only / informational; reliability evidence is absent. |
+| deposit | Deposit flow references authorize receiving customer funds. | Deposits remain excluded unless separately approved under governed Class B scope. |
+| yield | Yield routing intent allows protocol or treasury execution. | Yield remains subordinate and non-executing until explicit ADR and status authority exist. |
+| Copilot | Advisory Copilot can guide or execute financial action. | Copilot remains advisory, non-directive, non-executing, and subordinate. |
+
+## 8. Non-authorization statement
+
+This gap register is non-authoritative and documentation-only. It does not activate, sequence, approve, or implement Class B execution. Any future Class B implementation work still requires separate HEDGR_STATUS.md §7 naming, a bounded §7a execution brief, and any required accepted ADRs.

--- a/docs/ops/HEDGR_STATUS.md
+++ b/docs/ops/HEDGR_STATUS.md
@@ -567,6 +567,61 @@ Implementation posture preserved:
 - no ADR status changes
 - no successor implementation ticket
 
+### GOV-B-002 - Class B Eligibility Gap Register (documentation-only)
+
+Merged files:
+
+- `docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`
+- `docs/ops/HEDGR_STATUS.md`
+
+Implementation truth:
+
+- governance-only gap register added at `docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`
+- preserves repo-native memory of current evidence posture against `B-M1` through `B-M10`
+- records current posture as Pass: 3, Partial: 7, Fail: 0, Not assessed: 0
+- identifies future artifact types likely required before any Class B implementation proposal
+- does not propose or activate implementation
+
+Implementation posture preserved:
+
+- documentation-only governance artifact
+- no `apps/`
+- no `packages/`
+- no backend
+- no frontend implementation
+- no tests
+- no CI workflow changes
+- no ADR status changes
+- no successor implementation ticket
+- no custody, rails, deposits, withdrawals, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement authority
+
+### GOV-B-003 - Class B Artifact Dependency Map (documentation-only)
+
+Merged files:
+
+- `docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`
+- `docs/ops/HEDGR_STATUS.md`
+
+Implementation truth:
+
+- governance-only dependency map added at `docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`
+- maps dependency relationships between future Class B prerequisite artifacts identified in the Class B Eligibility Gap Register
+- consolidates the Class B governance spine without proposing or activating implementation
+- clarifies that dependency order is not backlog order, queue order, activation order, or implementation sequencing
+
+Implementation posture preserved:
+
+- documentation-only governance artifact
+- no `apps/`
+- no `packages/`
+- no backend
+- no frontend implementation
+- no tests
+- no CI workflow changes
+- no ADR status changes
+- no successor implementation ticket
+- no custody, rails, deposits, withdrawals, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement authority
+
 ### MC-S2-004 - Allocation bands UI
 
 Implementation truth:
@@ -1057,6 +1112,8 @@ Completed and merged:
 - `COP-GOV-001` - Copilot MVP advisory lane definition (documentation-only governance artifact; completed record **§52**)
 - `MC-S3-020` - MVP phased alignment (documentation-only governance readout; merged PR **#152**; completed record **§53**)
 - `GOV-B-001` - Class B Pilot Eligibility Standard (documentation-only governance standard; completed record **§54**)
+- `GOV-B-002` - Class B Eligibility Gap Register (documentation-only governance / evidence register; completed record **§55**)
+- `GOV-B-003` - Class B Artifact Dependency Map (documentation-only governance / dependency map; completed record **§56**)
 
 Current active ticket status:
 
@@ -1071,7 +1128,7 @@ Current active ticket status:
 - Cursor must not continue automatically into work beyond what is explicitly defined in this file for an active ticket.
 - Cursor must not drift beyond explicitly defined scope.
 
-**Last completed ticket (summary):** `GOV-B-001` — Class B Pilot Eligibility Standard (documentation-only governance standard defining minimum authority, ADR, legal/compliance, custody, rails, liquidity, UX/trust, ops/reconciliation, simulation/staging, and exclusion gates for future Class B pilot eligibility assessment; subordinate artifact at **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`**; **§7** / **§7a** restored to no-active-ticket state; no approved Class B implementation ticket created); completed record in **§54**.
+**Last completed ticket (summary):** `GOV-B-003` — Class B Artifact Dependency Map (documentation-only governance / dependency map converting the Class B Eligibility Gap Register into a dependency structure for future prerequisite artifacts; subordinate artifact at **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`**; dependency order is not backlog order, queue order, activation order, or implementation sequencing; **§7** / **§7a** remain in no-active-ticket state; no approved Class B implementation ticket created); completed record in **§56**.
 
 ---
 
@@ -1082,6 +1139,10 @@ Current active ticket status:
 When governance approves the next ticket, **§7** will name it and this section will hold the full execution brief until closeout.
 
 ---
+
+**Archived brief (GOV-B-003):** Class B Artifact Dependency Map — **documentation-only governance / dependency map**; scope held to **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`** and **`docs/ops/HEDGR_STATUS.md`**. Converted the Class B Eligibility Gap Register future artifact inventory into a dependency structure covering foundation, decision-prep, operational, UX / trust, and activation artifact classes. Mapped which future Class B prerequisite artifacts should precede, inform, or constrain others before any future Class B implementation proposal may be considered. This map does **not** answer which implementation ticket should be opened next and does **not** create a backlog, queue order, default next ticket, implementation authority, ADR acceptance, vendor approval, legal approval, custody approval, rail approval, or pilot approval. Dependency order is not backlog order, queue order, activation order, or implementation sequencing. **No** `apps/`, **no** `packages/`, **no** tests, **no** backend, **no** frontend implementation, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, **no** custody, rails, deposits, withdrawals, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement authority. Completed record: **§56**.
+
+**Archived brief (GOV-B-002):** Class B Eligibility Gap Register — **documentation-only governance / evidence register**; scope held to **`docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`** and **`docs/ops/HEDGR_STATUS.md`**. Preserved repo-native memory of the current evidence posture against **B-M1** through **B-M10** from the Class B Pilot Eligibility Standard, recording **Pass: 3**, **Partial: 7**, **Fail: 0**, **Not assessed: 0**. Identified existing evidence posture, gaps / blockers, likely future artifact types, authority notes, gap categories, future artifact map, and drift risks. This register does **not** conclude that Hedgr is Class B ready and does **not** activate, sequence, approve, or implement Class B execution. **No** `apps/`, **no** `packages/`, **no** tests, **no** backend, **no** frontend implementation, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, **no** custody, rails, deposits, withdrawals, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement authority. Completed record: **§55**.
 
 **Archived brief (GOV-B-001):** Class B Pilot Eligibility Standard — **documentation-only governance standard**; scope held to **`docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md`** and **`docs/ops/HEDGR_STATUS.md`**. Created the repo-native standard for assessing future Class B pilot eligibility before any manual / limited execution ticket involving deposits, withdrawals, custody, rails, reconciliation, or treasury operations may be proposed for **§7**. The standard defines mandatory criteria **B-M1** through **B-M10**, supporting criteria, a future evidence-table template, explicit non-authorization clauses, and future-ticket requirements. Eligibility means eligible for future **§7** / **§7a** consideration only. **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or copy changes, **no** CI workflow changes, **no** ADR status changes, **no** successor ticket, **no** Class B implementation approval, and **no** deposits, withdrawals, custody, rails, ledger mutation, stablecoin movement, treasury operations, Copilot execution, or customer fund movement authority. Completed record: **§54**.
 
@@ -2323,6 +2384,53 @@ This **§43** record was originally written in the same working-tree change-set 
 **Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or product copy edits, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, and **no** Class B approval. This closeout does **not** authorize deposits, withdrawals, custody activation, rails integration, ledger mutation, stablecoin movement, treasury operations, Copilot execution, backend workers, production rail integration, Class C automation, or customer fund movement.
 
 **Validation.** Documentation-only diff review, `git diff --check -- docs/ops/HEDGR_CLASS_B_PILOT_ELIGIBILITY_STANDARD.md docs/ops/HEDGR_STATUS.md`, scoped artifact review, and `git status --short` completed locally. No tests were run because the ticket scope explicitly excludes tests and product/runtime files.
+
+### Sequencing note
+
+**§7** / **§7a** record completion per governance; the **live** approved next ticket is whatever **§7** names (brief in **§7a**) — do not treat this completed-record footer as current sequencing authority.
+
+**Follow-ups:** Any successor appears only when **§7** is updated explicitly.
+
+---
+
+## 55. Completed execution ticket - GOV-B-002 (Class B Eligibility Gap Register)
+
+**Ticket:** `GOV-B-002` — Class B Eligibility Gap Register (documentation-only governance / evidence register)
+
+### Outcome (documentation-only)
+
+- **`docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`** — added the repo-native gap register preserving current evidence posture against **B-M1** through **B-M10** from the Class B Pilot Eligibility Standard
+- **`docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`** — recorded current posture as **Pass: 3**, **Partial: 7**, **Fail: 0**, **Not assessed: 0**
+- **`docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md`** — captured existing evidence posture, gaps / blockers, likely future artifact types, authority notes, grouped gap categories, future artifact map, drift risks, and required non-authorization statement
+- **`docs/ops/HEDGR_STATUS.md`** — added §6 merged-truth subsection `GOV-B-002`; updated last-completed summary; preserved §7 / §7a no-active-ticket posture; added §7a archived brief for `GOV-B-002`; §55 (this record)
+
+**Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or product copy edits, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, and **no** Class B approval. This closeout does **not** authorize custody, rails, deposits, withdrawals, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement.
+
+**Validation.** Documentation-only diff review, `git diff --check -- docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md docs/ops/HEDGR_STATUS.md`, scoped artifact review, and `git status --short` completed locally. No tests were run because the ticket scope explicitly excludes tests and product/runtime files.
+
+### Sequencing note
+
+**§7** / **§7a** record completion per governance; the **live** approved next ticket is whatever **§7** names (brief in **§7a**) — do not treat this completed-record footer as current sequencing authority.
+
+**Follow-ups:** Any successor appears only when **§7** is updated explicitly.
+
+---
+
+## 56. Completed execution ticket - GOV-B-003 (Class B Artifact Dependency Map)
+
+**Ticket:** `GOV-B-003` — Class B Artifact Dependency Map (documentation-only governance / dependency mapping)
+
+### Outcome (documentation-only)
+
+- **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`** — added the repo-native dependency map converting the Class B Eligibility Gap Register future artifact inventory into a dependency structure
+- **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`** — defined foundation, decision-prep, operational, UX / trust, and activation artifact classes
+- **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`** — mapped dependencies across legal / compliance, custody, rails, liquidity / withdrawal controls, ADR scoping, trust UX, pilot operations, reconciliation, support, audit evidence, staging/live separation, and future implementation-specific §7a brief artifacts
+- **`docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`** — added a non-authorizing dependency order and principles clarifying that dependency logic is not backlog order, queue order, activation order, or implementation sequencing
+- **`docs/ops/HEDGR_STATUS.md`** — added §6 merged-truth subsection `GOV-B-003`; updated the §7 completed list and last-completed summary; preserved §7 / §7a no-active-ticket posture; added §7a archived brief for `GOV-B-003`; §56 (this record)
+
+**Scope discipline held.** **No** `apps/`, **no** `packages/`, **no** `scripts/`, **no** `.github/`, **no** tests, **no** backend, **no** frontend implementation or product copy edits, **no** CI workflow changes, **no** ADR status changes, **no** successor implementation ticket, and **no** Class B approval. This closeout does **not** authorize custody, rails, deposits, withdrawals, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement.
+
+**Validation.** Documentation-only diff review, `git diff --check -- docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md docs/ops/HEDGR_STATUS.md`, scoped artifact review, and `git status --short` completed locally. No tests were run because the ticket scope explicitly excludes tests and product/runtime files.
 
 ### Sequencing note
 


### PR DESCRIPTION
## Summary

- Add `docs/ops/HEDGR_CLASS_B_ELIGIBILITY_GAP_REGISTER.md` as the Class B eligibility evidence gap register.
- Add `docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md` as the GOV-B-003 documentation-only dependency map.
- Update `docs/ops/HEDGR_STATUS.md` with minimal governance records for GOV-B-002 / GOV-B-003 while preserving `§7` / `§7a` no-active-ticket posture.

## Scope / authority

Documentation-only governance change. This PR does not authorize Class B execution, deposits, withdrawals, custody, rails, stablecoin conversion, ledger mutation, treasury operations, Copilot execution, Class C automation, or customer fund movement.

## Acceptance criteria

- [x] Class B Artifact Dependency Map exists at `docs/ops/HEDGR_CLASS_B_ARTIFACT_DEPENDENCY_MAP.md`.
- [x] Map references the eligibility standard and gap register as source inputs.
- [x] Map defines artifact classes.
- [x] Map includes the required dependency table.
- [x] Map includes a non-authorizing dependency order.
- [x] Map includes dependency principles.
- [x] Map states dependency order is not backlog order, queue order, activation order, or implementation sequencing.
- [x] Map ends with the required non-authorization statement.
- [x] `docs/ops/HEDGR_STATUS.md` includes the governance pointer / closeout record.
- [x] No implementation files, tests, workflows, backend, frontend, package files, or ADR statuses changed.
- [x] No Class B implementation ticket proposed or activated.

## Validation

- [x] `git diff --cached --check`
- [x] `pnpm run validate`
- [x] `NEXT_PUBLIC_AUTH_MODE=mock NEXT_PUBLIC_FX_MODE=stub NEXT_PUBLIC_MARKET_MODE=manual NEXT_PUBLIC_MARKET_SELECTED=UNKNOWN NEXT_PUBLIC_API_BASE_URL=http://localhost:5050 NEXT_PUBLIC_APP_ENV=dev NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=true STUB_MODE=true OPENAI_MODE=stub pnpm --filter @hedgr/frontend run e2e:ci` — 53 passed

## Solo QA Gate

- [x] Product label: `product:approved`
- [x] QA label: `qa:approved`
- [x] Area label: `area:docs`
- [x] Risk label: `risk:low`
- [x] Required checks expected: `validate`, `E2E smoke (@hedgr/frontend)`
