### PR TITLE
docs(agents): add codex branch safety rules

### DIFF
--- a/docs/agents/skills/codex-implementer.md
+++ b/docs/agents/skills/codex-implementer.md
@@ -63,6 +63,30 @@ You MUST NOT:
 If conflict is detected:
 → STOP and surface explicitly
 
+## Branch Safety Rule
+
+Before making any file amendment, documentation update, or implementation change, Codex MUST verify the current git branch.
+
+If the current branch is `main`, `master`, or any protected/default branch, Codex MUST NOT modify files directly.
+
+Codex MUST first create or request creation of a dedicated task branch using a clear, scoped name, for example:
+
+- `docs/repo-steward-status-reconcile`
+- `chore/codex-skill-branch-safety`
+- `feat/<ticket-id>-<short-description>`
+- `fix/<ticket-id>-<short-description>`
+
+This applies to both:
+- Repo Steward documentation/state updates
+- Implementer code or test changes
+
+Codex MUST NOT:
+- commit directly to `main`
+- amend protected branches
+- mix unrelated changes into the task branch
+- reuse stale branches without confirming scope alignment
+
+If branch creation is not possible, Codex must STOP and surface the issue before making changes.
 
 ---
 

--- a/docs/agents/skills/codex-repo-steward.md
+++ b/docs/agents/skills/codex-repo-steward.md
@@ -65,6 +65,30 @@ You MUST NOT:
 If conflict is detected:
 → STOP and surface explicitly
 
+## Branch Safety Rule
+
+Before making any file amendment, documentation update, or implementation change, Codex MUST verify the current git branch.
+
+If the current branch is `main`, `master`, or any protected/default branch, Codex MUST NOT modify files directly.
+
+Codex MUST first create or request creation of a dedicated task branch using a clear, scoped name, for example:
+
+- `docs/repo-steward-status-reconcile`
+- `chore/codex-skill-branch-safety`
+- `feat/<ticket-id>-<short-description>`
+- `fix/<ticket-id>-<short-description>`
+
+This applies to both:
+- Repo Steward documentation/state updates
+- Implementer code or test changes
+
+Codex MUST NOT:
+- commit directly to `main`
+- amend protected branches
+- mix unrelated changes into the task branch
+- reuse stale branches without confirming scope alignment
+
+If branch creation is not possible, Codex must STOP and surface the issue before making changes.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds explicit branch safety rules to the Codex Repo Steward and Codex Implementer skill docs so future Codex work verifies branch state before modifying files and avoids protected/default branch amendments.

## Scope
**In**
- `docs/agents/skills/codex-repo-steward.md`
- `docs/agents/skills/codex-implementer.md`
- Branch safety language for protected/default branches, scoped task branches, and stale-branch reuse checks

**Out**
- Runtime code changes
- App, package, workflow, backend, frontend, or test changes
- ADR status changes
- Sprint sequencing changes
- Implementation authority changes

## Acceptance Criteria (Gherkin)
- [x] Given Codex is operating under Repo Steward or Implementer skill docs, When file changes are needed, Then the skill docs require branch verification before modification.
- [x] Given Codex is on `main`, `master`, or another protected/default branch, When a change is requested, Then the skill docs require creating or requesting a dedicated scoped task branch first.
- [x] Given existing branches or mixed work may exist, When preparing work, Then the skill docs prohibit stale branch reuse without confirming scope alignment and prohibit mixing unrelated changes.

---

## Tests (author attestation)
- [x] Unit tests added/updated where logic changed — not applicable; docs-only change
- [x] E2E updated/added if user flows or critical paths changed — not applicable; no UI/runtime flow touched

---

## Merge Gates (system-enforced)
**Required checks**
- validate (unit, typecheck, lint)
- E2E smoke (@hedgr/frontend)

**Required labels**
- `product:approved` (HedgrOps)
- `qa:approved` (Codex QA)
- one `area:*`
- one `risk:*`

---

## Local Validation
- [x] `git diff --check -- docs/agents/skills/codex-repo-steward.md docs/agents/skills/codex-implementer.md`
- [x] `pnpm run validate`
  - trust:check passed
  - trust:phrases passed
  - Vitest passed: 60 files, 718 tests
  - typecheck passed
  - lint passed

Local E2E was not run because this PR is documentation-only and does not touch app/runtime/user flows; required CI E2E smoke remains the merge gate.

## Risk Classification
- Area: `area:docs`
- Risk: `risk:low`
- Money-path impact: none
- Trust / policy impact: indirect; clarifies branch safety for Codex skill operation only

## Flags / Environment
No flags, environment variables, secrets, or CI defaults changed.

## Documentation-Only Governance Attestation
- No runtime code changes
- No app/package/workflow/test changes
- No ADR status change
- No implementation authority created
- No custody, rails, deposits, withdrawals, ledger, treasury, Copilot execution, Class C automation, or customer fund movement authority created

## Rollback Strategy
- [x] Single revert commit / squash PR revert
- [x] No flag changes required
- [x] No data migration impact

## Security & Trust
- [x] No secrets introduced or exercised in CI
- [x] No live network dependency introduced in CI/E2E
- [x] CI hermetic posture unchanged

## Reviewer Guidance
- Start with `docs/agents/skills/codex-repo-steward.md` and `docs/agents/skills/codex-implementer.md`.
- Focus on whether the branch safety rule is clear enough for future Codex execution.
- Ignore runtime, UI, backend, frontend, and workflow surfaces; they are intentionally untouched.
