### PR TITLE
docs(ops): add MVP and weekly review reports

### DIFF
--- a/docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_014_TO_016.md
+++ b/docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_014_TO_016.md
@@ -1,0 +1,257 @@
+# HEDGR MVP PROCESS REVIEW - GOV-B-014 TO GOV-B-016
+
+## 1. Status / Authority / Scope / Last updated
+
+Status: `codex-synthesizer` review artifact only; descriptive evidence, not direction
+Authority: Subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and repo-native doctrine
+Scope: Completed tickets explicitly recorded in `docs/ops/HEDGR_STATUS.md`: `GOV-B-014`, `GOV-B-015`, `GOV-B-016` (inclusive)
+Last updated: 2026-06-06
+
+Review posture: `READ_ONLY`
+
+This report does not name a next ticket, propose sequencing, approve implementation, or alter `HEDGR_STATUS.md` `§7` / `§7a` authority.
+
+Default assumption preserved: the system remains **read-only / informational** unless repo authority explicitly authorizes otherwise.
+
+Included artifacts:
+
+- `docs/ops/HEDGR_STATUS.md`
+- `AGENTS.md`
+- `docs/ops/reviews/README.md`
+- `docs/doctrine/hedgr-mvp-project-specification.md`
+- `docs/doctrine/hedgr-whitepaper.md`
+- `docs/decisions/SPRINT-2-ADR-INDEX.md`
+- `docs/decisions/0013-allocation-bands-informational-not-accounting.md`
+- `docs/decisions/0014-stability-engine-read-only-in-sprint-2.md`
+- `docs/decisions/0015-stability-engine-is-the-system-center.md`
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_AUDIT_EVIDENCE_CHECKLIST.md`
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_STAGING_LIVE_STATE_SEPARATION_MEMO.md`
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_GOVERNANCE_SPINE_CLOSEOUT_ASSESSMENT.md`
+
+Excluded work:
+
+- in-progress or unmerged work
+- external activity not mirrored in repo authority
+- ticket activation, sequencing, or approval interpretation
+- `EVID-B-*` evidence-package work
+- `GOV-B-017` except as an ambiguity note about adjacent milestone boundaries
+
+---
+
+## 2. Purpose
+
+This report summarises a bounded slice of completed work: `GOV-B-014` through `GOV-B-016`.
+
+The aim is to evaluate whether this slice reinforces the MVP North Star at the governance/process layer versus advancing end-user capability, without creating new authority or inferring work not recorded in repo-native artifacts.
+
+---
+
+## 3. Governing inputs
+
+Primary repo-native truth surfaces used:
+
+- `docs/ops/HEDGR_STATUS.md` — current posture, merged implementation truth, completed-ticket records, and sequencing authority (`§7` / `§7a`)
+- `AGENTS.md` — repo execution rules, role boundaries, and action-control constraints
+- `docs/ops/reviews/README.md` — required review structure and non-authoritative guardrails
+- `docs/doctrine/hedgr-mvp-project-specification.md` — MVP execution classes (`A / B / C`), trust constraints, and product intent framing
+- `docs/doctrine/hedgr-whitepaper.md` — Stability Wallet / Stability Engine North Star framing
+
+Accepted ADRs referenced for boundary interpretation:
+
+- `docs/decisions/SPRINT-2-ADR-INDEX.md`
+- `docs/decisions/0015-stability-engine-is-the-system-center.md`
+- `docs/decisions/0014-stability-engine-read-only-in-sprint-2.md`
+- `docs/decisions/0013-allocation-bands-informational-not-accounting.md`
+
+Ticket-local artifacts used:
+
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_AUDIT_EVIDENCE_CHECKLIST.md` (`GOV-B-014`)
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_STAGING_LIVE_STATE_SEPARATION_MEMO.md` (`GOV-B-015`)
+- `docs/ops/governance/class-b/HEDGR_CLASS_B_GOVERNANCE_SPINE_CLOSEOUT_ASSESSMENT.md` (`GOV-B-016`)
+
+Repo-authoritative posture facts used in this review:
+
+- `docs/ops/HEDGR_STATUS.md` preserves the read-only / informational system posture.
+- `docs/ops/HEDGR_STATUS.md` `§7` does not authorize execution from this review; `§7` / `§7a` remain the only sequencing and activation surfaces.
+- `GOV-B-014` through `GOV-B-016` are completed documentation-only governance artifacts in merged repo truth.
+
+Review coverage note (repo-local evidence only):
+
+- `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_009_TO_013.md` exists, so this review selects the next completed 3-ticket block immediately following that slice in `docs/ops/HEDGR_STATUS.md` merged-truth order.
+
+Ambiguity note (surfaced, not resolved by inference):
+
+- `GOV-B-016` is a governance-spine closeout assessment, and `GOV-B-017` is the adjacent release reconciliation record that marks the spine closed in Notion staging. This report keeps scope to the next unreviewed 3-ticket block (`GOV-B-014` to `GOV-B-016`) and does not infer whether future review coverage should treat `GOV-B-017` as part of the same milestone or as a separate staging-reconciliation slice.
+
+---
+
+## 4. MVP North Star frame
+
+For this report, the MVP North Star is compressed into evaluation criteria:
+
+1. Stability-first: reinforces preservation and calm trust before yield or optimization.
+2. Engine-centered: preserves the Stability Engine as system center without implying execution authority.
+3. User-legible: improves clarity and reduces misleading interpretation risk.
+4. Non-misleading: does not imply ledger truth, fund movement, custody activation, or environment readiness without explicit authorization.
+5. Governed and reversible: keeps scope bounded, evidence-backed, hermetic in CI, and rollback-safe.
+
+---
+
+## 5. Ticket-by-ticket summary (GOV-B-014 to GOV-B-016)
+
+### GOV-B-014 - Class B Audit Evidence Checklist (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Defined audit evidence requirements across participant eligibility, user requests, manual review, deposits, withdrawals, custody, rails, stablecoin / conversion, fee / FX / spread, liquidity, reconciliation, support / disputes, incidents, governance overrides, and post-pilot review.
+- Added event-receipt, retention / access-control, audit-exception, post-pilot-review, prohibited-assumption, downstream-dependency, and open-question sections.
+- Preserved explicit non-authorization posture: evidence-shape identification only; no audit approval, retention approval, ledger truth approval, reconciliation approval, support approval, transaction-processing approval, or customer-money authority.
+
+Process meaning:
+
+- Strengthens the evidence model required before any future Class B consideration by making missing receipts, ownership, and retention assumptions visible instead of implicit.
+
+North Star alignment:
+
+- Aligned at the trust-governance layer: it makes unsupported claims harder by requiring evidence shape before any future authority widening.
+
+### GOV-B-015 - Class B Staging / Live-State Separation Memo (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Defined separation requirements for mock / local simulation, prototype / design-only, sandbox, internal test, manual pilot candidate, limited live pilot candidate, and production / live states.
+- Added environment separation matrix, environment label template, environment evidence tagging, drift-risk, prohibited-assumption, downstream-dependency, and open-question sections.
+- Preserved explicit non-authorization posture: no staging approval, live approval, production approval, sandbox approval, pilot approval, or customer-money movement authority.
+
+Process meaning:
+
+- Reduces one of the highest trust risks in future Class B work: simulated, candidate, or sandbox states being misread as live customer-money truth or implementation readiness.
+
+North Star alignment:
+
+- Aligned: reinforces calm truthfulness, visible environment boundaries, and anti-drift discipline over readiness theater.
+
+### GOV-B-016 - Class B Governance Spine Closeout Assessment (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Assessed `GOV-B-001` through `GOV-B-015` as a completed documentation-only prerequisite spine for future Class B consideration.
+- Inventoried the spine artifacts, assessed each spine layer, recorded what the spine proves and does not authorize, identified remaining blockers, and preserved future activation requirements.
+- Recorded a documentation-only closeout verdict while explicitly preserving that this does not conclude Class B readiness or create a successor implementation ticket.
+
+Process meaning:
+
+- Closes the governance-spine loop as documentation-only prerequisite work, while explicitly preventing closeout language from being misread as readiness or execution permission.
+
+North Star alignment:
+
+- Aligned: consolidates governance evidence without widening system authority or changing the read-only / informational posture.
+
+---
+
+## 6. Process assessment
+
+Overall characterization:
+
+- This slice is **governance hardening and documentation-only closeout**, not runtime capability expansion.
+- The work reinforces two process themes:
+  1. evidence must exist in a reviewable form before future authority widening is even considered; and
+  2. environment and milestone language must not be allowed to drift into implied readiness, pilot approval, or live-state truth.
+
+What held well:
+
+- **Explicit non-authorization language stayed intact** across all three tickets.
+- **Evidence discipline deepened** from abstract prerequisites into receipt, ownership, retention, and exception templates.
+- **Environment-state ambiguity was treated as a first-class trust risk**, not as a UI or staging detail.
+- **Closeout posture remained conservative**: `GOV-B-016` closes the governance spine as documentation-only rather than converting completeness into readiness.
+
+What remains incomplete (not defects in this slice's scope):
+
+- No audit operations, retention policy, reconciliation operations, support operations, or live evidence capture loops are approved or active.
+- No environment-state implementation exists in product/runtime surfaces; `GOV-B-015` is a governance boundary memo, not shipped state labeling behavior.
+- No Class B execution, pilot operations, customer-money movement, custody activation, rail activation, or ledger-truth authority is recorded.
+
+Confirmatory vs capability-progressing:
+
+- Confirmatory / governance hardening: all tickets in this slice.
+- Capability-progressing: none in this slice.
+
+---
+
+## 7. Execution classification (A / B / C)
+
+Current execution class for this slice:
+
+- **Class A - governance / documentation / evidence reinforcement:** `GOV-B-014`, `GOV-B-015`, `GOV-B-016`
+- **Class B - manual / limited execution:** none in scope
+- **Class C - automated execution:** none in scope
+
+Default posture preserved (repo authority):
+
+- System remains **read-only / informational** unless repo authority explicitly authorizes otherwise.
+
+Movement toward execution layers:
+
+- No movement toward pilot activation, custody operations, rail operations, stablecoin conversion, withdrawals execution, reconciliation execution, support operations, ledger mutation, treasury authority, Copilot execution, or customer fund movement authority is recorded in this slice.
+
+---
+
+## 8. Capability progression
+
+User capabilities advanced:
+
+- No new user-facing runtime capability is recorded in this slice.
+
+Capabilities reinforced (indirectly):
+
+- Stronger evidence and receipt discipline for any future high-stakes manual flow.
+- Stronger anti-drift separation between mock, prototype, sandbox, internal-test, pilot-candidate, and live states.
+- Stronger documentation-only closeout discipline so milestone completion is less likely to be misread as operational readiness.
+
+---
+
+## 9. Trust-surface coverage
+
+Trust surfaces reinforced in this slice (documentation-only constraints):
+
+- **Audit evidence discipline:** ownership, receipts, exceptions, and retention questions (`GOV-B-014`)
+- **Environment-state legibility:** labels, evidence tags, and cross-environment misread prevention (`GOV-B-015`)
+- **Closeout-language discipline:** what a completed governance spine proves and does not authorize (`GOV-B-016`)
+
+Trust surfaces explicitly not advanced:
+
+- No live audit trail, no retention/access-control implementation, no operational environment labeling in product code, no rail/custody/provider evidence, no reconciliation execution, and no support or dispute operations are recorded as active in this slice.
+
+---
+
+## 10. North Star verdict
+
+Verdict (evidence-only):
+
+- `GOV-B-014` through `GOV-B-016` are strongly aligned with the MVP North Star at the **governance and trust-hardening layer**.
+- This slice improves the repo's resistance to three common failure modes: unsupported claims, environment-state misread, and closeout-language drift.
+- This slice does **not** advance end-user capability directly and does **not** change the repo's read-only / informational execution posture.
+
+---
+
+## 11. Risks / notes
+
+Risks (evidence-only):
+
+- **Closeout misread risk remains:** even with explicit non-authorizing language, a completed governance-spine closeout can still be over-read outside repo-native authority surfaces as Class B readiness.
+- **Template gravity risk remains:** evidence and environment templates can attract operational assumptions if later readers ignore their explicit `TBD` and non-approval posture.
+- **Staging adjacency ambiguity remains:** because `GOV-B-017` immediately reconciles release state after `GOV-B-016`, milestone interpretation can drift if readers collapse closeout assessment and staging reconciliation into a single readiness event.
+
+Notes:
+
+- These tickets are recorded as completed documentation-only governance artifacts in `docs/ops/HEDGR_STATUS.md`. This review does not infer any in-progress work, external activity, or successor sequencing beyond recorded merged truth.
+
+---
+
+## 12. Optional non-authoritative evaluation criteria
+
+This review used the following non-authoritative criteria (interpretation aids only):
+
+- Does the slice reduce the chance that documentation, staging, or evidence language will be mistaken for execution authority?
+- Does the slice strengthen trust-surface clarity without implying ledger truth, custody truth, or live-state truth?
+- Does the slice preserve the read-only / informational default while improving the quality of future scrutiny inputs?

--- a/docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_017_TO_EVID_B_004.md
+++ b/docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_017_TO_EVID_B_004.md
@@ -1,0 +1,300 @@
+# HEDGR MVP PROCESS REVIEW - GOV-B-017 TO EVID-B-004
+
+## 1. Status / Authority / Scope / Last updated
+
+Status: `codex-synthesizer` review artifact only; descriptive evidence, not direction
+Authority: Subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and repo-native doctrine
+Scope: Completed tickets explicitly recorded in `docs/ops/HEDGR_STATUS.md`: `GOV-B-017`, `EVID-B-001`, `EVID-B-002`, `EVID-B-003`, and `EVID-B-004` (inclusive)
+Last updated: 2026-06-06
+
+Review posture: `READ_ONLY`
+
+This report does not name a next ticket, propose sequencing, approve implementation, or alter `docs/ops/HEDGR_STATUS.md` `§7` / `§7a` authority.
+
+Default assumption preserved: the system remains **read-only / informational** unless repo authority explicitly authorizes otherwise.
+
+Included artifacts:
+
+- `docs/ops/HEDGR_STATUS.md`
+- `AGENTS.md`
+- `docs/ops/reviews/README.md`
+- `docs/doctrine/hedgr-mvp-project-specification.md`
+- `docs/doctrine/hedgr-whitepaper.md`
+- `docs/decisions/SPRINT-2-ADR-INDEX.md`
+- `docs/decisions/0013-allocation-bands-informational-not-accounting.md`
+- `docs/decisions/0014-stability-engine-read-only-in-sprint-2.md`
+- `docs/decisions/0015-stability-engine-is-the-system-center.md`
+- `docs/ops/NOTION_GOVERNANCE_STAGING.md`
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_EVIDENCE_GATHERING_PLAN.md`
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_EVIDENCE_REGISTRY.md`
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_LEGAL_COMPLIANCE_EVIDENCE_PACKAGE.md`
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_JURISDICTION_SELECTION_EVIDENCE_PACKAGE.md`
+
+Excluded work:
+
+- in-progress or unmerged work
+- external activity not mirrored in repo authority
+- ticket activation, sequencing, or approval interpretation
+- `EVID-B-005` and later evidence-package work
+- any inference that evidence-gathering artifacts imply ADR readiness, implementation readiness, Class B readiness, or customer-money authority
+
+---
+
+## 2. Purpose
+
+This report summarises a bounded slice of completed work: `GOV-B-017` through `EVID-B-004`.
+
+The aim is to evaluate whether this slice reinforces the MVP North Star at the governance/process layer versus advancing end-user capability, without creating new authority or inferring work not recorded in repo-native artifacts.
+
+---
+
+## 3. Governing inputs
+
+Primary repo-native truth surfaces used:
+
+- `docs/ops/HEDGR_STATUS.md` — current posture, merged implementation truth, completed-ticket records, and sequencing authority (`§7` / `§7a`)
+- `AGENTS.md` — repo execution rules, role boundaries, and action-control constraints
+- `docs/ops/reviews/README.md` — required review structure and non-authoritative guardrails
+- `docs/doctrine/hedgr-mvp-project-specification.md` — MVP execution classes (`A / B / C`), trust constraints, and product intent framing
+- `docs/doctrine/hedgr-whitepaper.md` — Stability Wallet / Stability Engine North Star framing
+
+Accepted ADRs referenced for boundary interpretation:
+
+- `docs/decisions/SPRINT-2-ADR-INDEX.md`
+- `docs/decisions/0015-stability-engine-is-the-system-center.md`
+- `docs/decisions/0014-stability-engine-read-only-in-sprint-2.md`
+- `docs/decisions/0013-allocation-bands-informational-not-accounting.md`
+
+Ticket-local artifacts used:
+
+- `docs/ops/NOTION_GOVERNANCE_STAGING.md` (`GOV-B-017`)
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_EVIDENCE_GATHERING_PLAN.md` (`EVID-B-001`)
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_EVIDENCE_REGISTRY.md` (`EVID-B-002`)
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_LEGAL_COMPLIANCE_EVIDENCE_PACKAGE.md` (`EVID-B-003`)
+- `docs/ops/governance/class-b/evidence/HEDGR_CLASS_B_JURISDICTION_SELECTION_EVIDENCE_PACKAGE.md` (`EVID-B-004`)
+
+Repo-authoritative posture facts used in this review:
+
+- `docs/ops/HEDGR_STATUS.md` preserves the read-only / informational system posture.
+- `docs/ops/HEDGR_STATUS.md` `§7` and `§7a` remain the only sequencing and activation surfaces.
+- `GOV-B-017` and `EVID-B-001` through `EVID-B-004` are completed documentation-only governance artifacts in merged repo truth.
+
+Review coverage note (repo-local evidence only):
+
+- `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_014_TO_016.md` exists, so this review selects the next unreviewed 5-ticket block immediately following that slice in `docs/ops/HEDGR_STATUS.md` merged-truth order.
+
+Ambiguity note (surfaced, not resolved by inference):
+
+- This slice crosses a boundary between two adjacent but different governance meanings: `GOV-B-017` is the release reconciliation that closes the **Class B Pilot Governance Spine**, while `EVID-B-001` through `EVID-B-004` begin the separate **Class B Evidence Gathering** lane.
+- They are grouped here because they are the next completed tickets in merged-truth order and fit the README target of reviewing the next unreviewed 3-5 completed tickets.
+- This report does **not** infer that spine closeout and evidence-gathering initiation are one milestone, one approval event, or one readiness verdict.
+
+---
+
+## 4. MVP North Star frame
+
+For this report, the MVP North Star is compressed into evaluation criteria:
+
+1. Stability-first: reinforces preservation and calm trust before yield or optimization.
+2. Engine-centered: preserves the Stability Engine as system center without implying execution authority.
+3. User-legible: improves clarity and reduces misleading interpretation risk.
+4. Non-misleading: does not imply ledger truth, fund movement, legal sufficiency, jurisdiction approval, or operational readiness without explicit authorization.
+5. Governed and reversible: keeps scope bounded, evidence-backed, hermetic in CI, and rollback-safe.
+
+---
+
+## 5. Ticket-by-ticket summary (GOV-B-017 to EVID-B-004)
+
+### GOV-B-017 - Class B Governance Spine Release Reconciliation (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Marked the `Class B Pilot Governance Spine` release closed / complete in `docs/ops/NOTION_GOVERNANCE_STAGING.md`.
+- Preserved `GOV-B-001` through `GOV-B-016` as done, documentation-only, and non-authorizing, while adding `GOV-B-017` as documentation-only reconciliation.
+- Clarified that release closeout does not mean Class B readiness, pilot readiness, execution readiness, implementation readiness, staging approval, live approval, or customer-money authority.
+
+Process meaning:
+
+- Converts governance-spine completion into a cleaner downstream record without allowing release closeout language to become readiness theater.
+
+North Star alignment:
+
+- Aligned at the governance-integrity layer: reduces the risk that milestone closure is misread as runtime or customer-money readiness.
+
+### EVID-B-001 - Class B Evidence Gathering Plan (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Added the post-spine evidence-gathering plan defining evidence packages, source classification, evidence acceptance states, freshness expectations, blocker handling, review gates, and future-work boundaries.
+- Created / updated `Class B Evidence Gathering` in `docs/ops/NOTION_GOVERNANCE_STAGING.md` as a distinct governance-only release track following the closed governance spine.
+- Preserved explicit non-authorization posture: evidence planning only; no execution approval, ADR acceptance, implementation approval, or customer-money authority.
+
+Process meaning:
+
+- Moves the repo from prerequisite-definition into evidence-shape definition without claiming that evidence exists, is sufficient, or is accepted.
+
+North Star alignment:
+
+- Aligned: strengthens trust by formalizing what would count as evidence before any future authority widening is even reviewed.
+
+### EVID-B-002 - Class B Evidence Registry Initialization (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Added the working evidence registry listing required packages, current evidence states, source expectations, owner placeholders, freshness expectations, blockers, and downstream uses.
+- Added evidence-state and source-class legends, package-to-spine mapping, update rules, intake template, and review-log template.
+- Preserved explicit non-authorization posture: registry initialization does not mean evidence acceptance, ADR drafting readiness, implementation readiness, or customer-money authority.
+
+Process meaning:
+
+- Converts evidence-gathering from a conceptual plan into a maintainable registry, while keeping missing evidence explicitly missing rather than implied.
+
+North Star alignment:
+
+- Aligned at the trust-governance layer: it makes unsupported readiness claims harder by requiring evidence-state visibility.
+
+### EVID-B-003 - Class B Legal / Compliance Evidence Package Skeleton (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Added the legal / compliance evidence package skeleton with required evidence items, source expectations, open questions, blocker mapping, freshness expectations, and downstream dependencies.
+- Updated the registry to reference the package shell while preserving the package evidence state as question-framed / missing.
+- Preserved explicit non-authorization posture: no legal advice, regulatory approval, evidence acceptance, ADR readiness, implementation approval, or customer-money authority.
+
+Process meaning:
+
+- Begins evidence packaging by turning a major blocker area into an inspectable shell, but deliberately stops short of claiming the evidence has been gathered or cleared.
+
+North Star alignment:
+
+- Aligned: preserves non-misleading posture around legal and compliance unknowns that would materially affect any future user-facing claims.
+
+### EVID-B-004 - Class B Jurisdiction Selection Evidence Package Skeleton (documentation-only)
+
+Repo-recorded changes (from `docs/ops/HEDGR_STATUS.md` and ticket artifact):
+
+- Added the jurisdiction-selection evidence package skeleton with required evidence items, source expectations, open jurisdiction questions, comparison template, blocker mapping, freshness expectations, and downstream dependencies.
+- Updated the registry to reference the jurisdiction package shell while preserving the evidence state as question-framed / missing.
+- Preserved explicit non-authorization posture: no jurisdiction selection, ranking, recommendation, legal approval, evidence acceptance, ADR readiness, implementation approval, or customer-money authority.
+
+Process meaning:
+
+- Makes future jurisdiction assumptions explicit and reviewable instead of allowing them to remain hidden defaults.
+
+North Star alignment:
+
+- Aligned: reduces the chance that future MVP or Class B framing quietly assumes a legal or geographic footing that repo authority has not approved.
+
+---
+
+## 6. Process assessment
+
+Overall characterization:
+
+- This slice is **governance closeout plus evidence-lane initialization**, not runtime capability expansion.
+- It preserves a conservative sequence: first close the documentation-only prerequisite spine (`GOV-B-017`), then define how future evidence would be gathered and tracked (`EVID-B-001` through `EVID-B-004`).
+
+What held well:
+
+- **Closeout language remained constrained.** `GOV-B-017` explicitly blocks readiness inflation from release-reconciliation wording.
+- **Evidence discipline became structured.** `EVID-B-001` and `EVID-B-002` define package, state, freshness, blocker, and review logic rather than leaving evidence as loose future intent.
+- **Major uncertainty classes stayed visible.** `EVID-B-003` and `EVID-B-004` encode legal / compliance and jurisdiction questions as missing or question-framed, not as implied approvals.
+- **Repo authority stayed central.** Every artifact keeps `§7` / `§7a` as the only activation surfaces.
+
+What remains incomplete (not defects in this slice's scope):
+
+- No evidence package in scope is recorded as gathered, accepted, or sufficient.
+- No ADR drafting readiness, implementation-proposal preflight readiness, Class B readiness, or pilot readiness is recorded.
+- No runtime, backend, custody, rails, stablecoin conversion, reconciliation operations, support operations, audit operations, or customer-money authority is active.
+
+Confirmatory vs capability-progressing:
+
+- Confirmatory / governance hardening: all tickets in this slice.
+- Capability-progressing: none in this slice.
+
+---
+
+## 7. Execution classification (A / B / C)
+
+Current execution class for this slice:
+
+- **Class A - governance / documentation / evidence reinforcement:** `GOV-B-017`, `EVID-B-001`, `EVID-B-002`, `EVID-B-003`, `EVID-B-004`
+- **Class B - manual / limited execution:** none in scope
+- **Class C - automated execution:** none in scope
+
+Default posture preserved (repo authority):
+
+- System remains **read-only / informational** unless repo authority explicitly authorizes otherwise.
+
+Movement toward execution layers:
+
+- No movement toward pilot activation, custody operations, rail operations, stablecoin conversion, withdrawal execution, reconciliation execution, support operations, ledger mutation, treasury authority, Copilot execution, or customer fund movement authority is recorded in this slice.
+
+---
+
+## 8. Capability progression
+
+User capabilities advanced:
+
+- No new user-facing runtime capability is recorded in this slice.
+
+Capabilities reinforced (indirectly):
+
+- Stronger downstream clarity that governance-spine completion is not readiness.
+- Stronger evidence-shape discipline for future legal / compliance and jurisdiction questions.
+- Stronger maintainability for future evidence review through the registry and package-shell structure.
+
+---
+
+## 9. Trust-surface coverage
+
+Trust surfaces reinforced in this slice (documentation-only constraints):
+
+- **Milestone closeout meaning:** prevents release closure from being misread as implementation or customer-money readiness (`GOV-B-017`)
+- **Evidence-state legibility:** missing, question-framed, requested, received, stale, conflicting, and review-state distinctions (`EVID-B-001`, `EVID-B-002`)
+- **Legal / compliance claim restraint:** no unsupported claims about regulatory perimeter, eligibility, disclosures, or legal sufficiency (`EVID-B-003`)
+- **Jurisdiction assumption restraint:** no quiet defaulting to an approved legal / geographic operating context (`EVID-B-004`)
+
+Trust surfaces still not advanced by this slice (not defects in scope):
+
+- live operational proof
+- approved customer eligibility model
+- approved custody model
+- approved rails or vendor permissions
+- approved withdrawal or liquidity operations
+- accepted reconciliation truth model
+- accepted audit / retention control posture
+
+---
+
+## 10. North Star verdict
+
+For `GOV-B-017` through `EVID-B-004`, repo-recorded work remains aligned with the MVP North Star at the **governance integrity and evidence-discipline** layer.
+
+This slice does not expand MVP functional breadth or move the product toward active execution layers. Instead, it reduces the risk of false readiness by:
+
+- keeping governance-spine closeout non-authorizing
+- defining evidence package and registry structure before evidence is treated as usable
+- preserving major legal and jurisdiction questions as unresolved rather than assumed
+
+The slice should be understood as **anti-misinterpretation and evidence-framing work**, not as proof of Class B readiness, implementation readiness, or MVP capability expansion.
+
+---
+
+## 11. Risks / notes
+
+- Mixed-slice ambiguity remains real: `GOV-B-017` is a governance-spine release reconciliation, while `EVID-B-001` through `EVID-B-004` are the first evidence-gathering artifacts. This report includes both because they are the next completed tickets in merged-truth order, not because repo authority says they are one milestone.
+- Evidence-structure progress can be over-read as evidence progress. In this slice, most evidence remains framed or missing; the repo does not record acceptance or sufficiency.
+- Because the work is documentation-only and evidence-only, MVP capability gaps remain unchanged. That is not a defect in this report's scope, but it matters for interpretation.
+
+---
+
+## 12. Non-authoritative evaluation criteria (optional)
+
+If used as a consistent rubric for future MVP Process Reviews (non-binding):
+
+1. Does the slice reduce the risk of misleading users or operators about what is real, approved, live, or ready?
+2. Does it preserve `§7` / `§7a` as the only activation surfaces?
+3. Does it make blockers and evidence states more explicit rather than less explicit?
+4. Does it avoid converting governance completion or evidence scaffolding into implied product capability?
+5. Does it reinforce calm, stability-first, trust-first interpretation rather than execution theater?

--- a/docs/ops/reviews/weekly/2026-06-05-weekly-review.md
+++ b/docs/ops/reviews/weekly/2026-06-05-weekly-review.md
@@ -1,0 +1,280 @@
+# 2026-06-05 Weekly Review
+
+## 1. Status / Authority / Scope / Last updated
+
+Status: Non-authoritative weekly review artifact; descriptive evidence only, not direction
+Authority: Subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and repo-native doctrine (`docs/doctrine/*`, `.cursorrules`)
+Scope: Repo-native, explicit merged-work evidence within the weekly time window ending on 2026-06-05; excludes in-progress or inferred work
+
+Weekly time window (end date = run date): 2026-05-30 through 2026-06-05 (inclusive; AWST)
+
+Execution mode: `READ_ONLY` (codex-synthesizer posture)
+Last updated: 2026-06-05
+
+This report does not name a next ticket, activate work, suggest sequencing, approve implementation, or alter `docs/ops/HEDGR_STATUS.md` §7 / §7a authority.
+
+Included merged-work evidence (explicit commits on `main` in this window):
+
+- `8bae9fa` — docs(ops): add May 29 review artifacts (#184)
+- `58a0b63` — docs(ops): add EVID-B-005 eligibility evidence package (#185)
+- `b0cb982` — docs(ops): add EVID-B-006 KYC AML evidence package (#186)
+- `2a13a78` — docs(ops): add Notion reconciliation report (#187)
+- `a527071` — docs(ops): add EVID-B-007 custody evidence package (#188)
+- `39eaec3` — docs(ops): add EVID-B-008 rail vendor evidence shell (#189)
+- `6ed6d17` — docs(ops): capture STRAT-001 treasury thesis (#190)
+- `40e09a8` — docs(ops): add EVID-B-009 settlement finality package (#191)
+- `621f275` — docs(ops): add stablecoin conversion evidence package (#192)
+- `3cc0989` — docs(ops): add EVID-B-011 evidence package (#193)
+- `84fee09` — docs(ops): add EVID-B-012 withdrawal evidence package (#194)
+- `3492cee` — docs(ops): add EVID-B-013 trust ux disclosure package (#195)
+- `4a7e0c9` — docs(ops): add Pilot Ops evidence package skeleton (#196)
+- `d34e62f` — docs(ops): add reconciliation evidence package (#197)
+
+Completed-ticket evidence included (only where completion is explicit in repo authority):
+
+- `EVID-B-005` (documentation-only) — Class B Customer Eligibility Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §78)
+- `EVID-B-006` (documentation-only) — Class B KYC / AML Responsibility Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §79)
+- `EVID-B-007` (documentation-only) — Class B Custody Provider / Model Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §80)
+- `EVID-B-008` (documentation-only) — Class B Rail / Vendor Permission Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §81)
+- `EVID-B-009` (documentation-only) — Class B Rail Settlement / Finality Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §82)
+- `EVID-B-010` (documentation-only) — Class B Stablecoin / Conversion Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §83)
+- `EVID-B-011` (documentation-only) — Class B Fee / FX / Spread Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §84)
+- `EVID-B-012` (documentation-only) — Class B Liquidity / Withdrawal Control Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §85)
+- `EVID-B-013` (documentation-only) — Class B Trust UX / Disclosure Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §86)
+- `EVID-B-014` (documentation-only) — Class B Pilot Ops Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §87)
+- `EVID-B-015` (documentation-only) — Class B Reconciliation Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §88)
+
+Included merged artifacts without completed-ticket status in `HEDGR_STATUS.md`:
+
+- `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_009_TO_013.md`
+- `docs/ops/reviews/weekly/2026-05-29-weekly-review.md`
+- `docs/ops/reconciliation/NOTION_REPO_RECONCILIATION_REPORT_2026-06-01.md`
+- `docs/ops/strategy/STRAT-001-WHATSAPP-TREASURY-INTERFACE-THESIS.md`
+- `.github/workflows/validate.yml` (`node-version-file: '.nvmrc'` alignment)
+
+Excluded (by rule):
+
+- Any work not merged to the repo within the time window.
+- Any in-progress tickets not explicitly recorded as completed in `docs/ops/HEDGR_STATUS.md`.
+- Any external-only activity not mirrored by repo artifacts.
+- Any interpretation of `STRAT-001`, review artifacts, or reconciliation reporting as implementation approval, sequencing authority, or completed execution unless repo authority says so explicitly.
+
+---
+
+## 2. Purpose
+
+This weekly review summarises what the repo explicitly shows was merged within the time window ending 2026-06-05, and assesses (non-authoritatively) how that merged work reinforces Hedgr's MVP North Star and trust-surface posture without creating sequencing, activation, or approval authority.
+
+---
+
+## 3. Governing inputs used
+
+- `docs/ops/reviews/README.md` — review guardrails and required structure
+- `docs/ops/HEDGR_STATUS.md` — canonical merged-truth, posture, completed-ticket records, and the §7 / §7a sequencing authority constraint
+- `AGENTS.md` — repo execution posture and CI / hermetic constraints
+- `docs/doctrine/hedgr-whitepaper.md` — North Star framing (Stability Wallet thesis; Stability Engine as system center)
+- `docs/doctrine/hedgr-mvp-project-specification.md` — doctrine-grade MVP constraints, execution classes A/B/C, and trust boundaries
+- `docs/decisions/SPRINT-2-ADR-INDEX.md` — accepted ADR index and read-only / governance-boundary context
+- Prior weekly structure reference: `docs/ops/reviews/weekly/2026-05-29-weekly-review.md`
+- Repo log evidence for this window: `git log --since 2026-05-30 --until 2026-06-05` (commit subjects listed in §1)
+
+Repo-authoritative boundary facts used in this review:
+
+- `docs/ops/HEDGR_STATUS.md` §7 / §7a are the only sequencing / activation surfaces; this review does not introduce or imply sequencing.
+- Execution classes A/B/C are doctrine-defined and governance-gated; documentation, reconciliation, review, strategy-capture, and CI-alignment artifacts do not create Class B or Class C authority by themselves.
+
+If ambiguity exists between external narratives and repo truth, repo truth wins; this review surfaces ambiguity rather than resolving it by inference.
+
+---
+
+## 4. MVP North Star frame
+
+For this weekly review, the MVP North Star is compressed into the following evaluation criteria:
+
+1. Stability-first: reinforce preservation and calm trust before yield or growth.
+2. Liquidity integrity: treat withdrawal-path honesty, liquidity control, and settlement/reconciliation clarity as core trust surfaces without implying operational readiness.
+3. Governed phases: preserve the execution-class gating model (A informational / B manual-limited / C automated) without implying Class B/C readiness through governance artifacts alone.
+4. Non-misleading: do not imply legal clearance, vendor approval, accounting truth, ledger truth, fund movement, or autonomous execution unless explicitly authorized.
+5. Engine-centered and subordinate layers: preserve Stability Engine centering while keeping review, strategy, and Copilot-adjacent artifacts subordinate to repo authority.
+
+---
+
+## 5. Time-based summary (repo-native evidence only)
+
+### 2026-06-01 — Review cadence continued; CI Node version alignment recorded; customer eligibility and KYC / AML evidence shells added
+
+What changed (repo evidence):
+
+- Added review artifacts:
+  - `docs/ops/reviews/weekly/2026-05-29-weekly-review.md`
+  - `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_009_TO_013.md`
+- Updated `.github/workflows/validate.yml` to use `node-version-file: '.nvmrc'` instead of a hard-coded Node version.
+- Added the Customer Eligibility Evidence Package skeleton and recorded `EVID-B-005` in `docs/ops/HEDGR_STATUS.md`.
+- Added the KYC / AML Responsibility Evidence Package skeleton and recorded `EVID-B-006` in `docs/ops/HEDGR_STATUS.md`.
+- Added `docs/ops/reconciliation/NOTION_REPO_RECONCILIATION_REPORT_2026-06-01.md`.
+
+Meaning (non-authoritative interpretation):
+
+- Review cadence and repo-to-Notion reconciliation evidence continued as interpretive / reporting layers without widening execution authority.
+- CI guardrail posture improved by aligning `validate` with the repo-pinned Node version source of truth.
+- The Class B evidence lane expanded from legal/jurisdiction framing into participant eligibility and KYC / AML responsibility questions while preserving missing/question-framed evidence states rather than implying answers.
+
+### 2026-06-02 — Custody, rail/vendor, settlement/finality, stablecoin/conversion, fee/FX/spread, and strategy-memory artifacts expanded the evidence frame
+
+What changed (repo evidence):
+
+- Added and recorded completed documentation-only evidence package skeletons:
+  - `EVID-B-007` — custody provider / model
+  - `EVID-B-008` — rail / vendor permission
+  - `EVID-B-009` — rail settlement / finality
+  - `EVID-B-010` — stablecoin / conversion
+  - `EVID-B-011` — fee / FX / spread
+- Added `docs/ops/strategy/STRAT-001-WHATSAPP-TREASURY-INTERFACE-THESIS.md` as thesis capture / institutional memory.
+
+Meaning (non-authoritative interpretation):
+
+- The repo widened evidence coverage across the main operational trust surfaces required before any future Class B consideration: custody, vendor permissions, settlement finality, conversion pathways, and pricing/fee clarity.
+- `STRAT-001` preserved an exploratory thesis as institutional memory only; the artifact remains explicitly subordinate and does not function as execution authority or ticket activation.
+
+### 2026-06-03 — Liquidity/withdrawal, trust UX/disclosure, and Pilot Ops evidence shells extended the Class B evidence lane
+
+What changed (repo evidence):
+
+- Added and recorded completed documentation-only evidence package skeletons:
+  - `EVID-B-012` — liquidity / withdrawal control
+  - `EVID-B-013` — trust UX / disclosure
+  - `EVID-B-014` — Pilot Ops
+
+Meaning (non-authoritative interpretation):
+
+- The evidence lane moved beyond legal/vendor/custody questions into user-facing trust communication and pilot-operations dependencies.
+- The merged artifacts continued to frame unresolved operational questions explicitly while preserving negative-authority language: no approvals, no evidence acceptance, no Class B readiness, and no customer-money authority.
+
+### 2026-06-04 — Reconciliation evidence shell completed the current documented evidence-package sweep
+
+What changed (repo evidence):
+
+- Added and recorded `EVID-B-015` — Reconciliation Evidence Package Skeleton.
+- Updated the Class B Evidence Registry to reference the reconciliation package while preserving package state as question-framed / missing.
+
+Meaning (non-authoritative interpretation):
+
+- The repo now contains explicit documentation-only evidence shells across eligibility, compliance responsibility, custody, vendor permissioning, settlement/finality, stablecoin conversion, fee/FX/spread, liquidity/withdrawal control, trust disclosures, pilot operations, and reconciliation.
+- This is evidence-lane coverage expansion, not evidence acceptance or operational readiness.
+
+---
+
+## 6. Process assessment
+
+What held well (descriptive):
+
+- **Authority hygiene:** The merged EVID-B artifacts repeatedly deny approval, readiness, evidence acceptance, and successor-ticket creation, preserving `docs/ops/HEDGR_STATUS.md` §7 / §7a as the only activation surface.
+- **Coverage discipline:** The evidence lane expanded in a structured progression across operational trust surfaces without silently switching from scaffolding to conclusions.
+- **Repo-first reconciliation posture:** The Notion reconciliation report and `HEDGR_STATUS.md` updates reinforce repo authority as the upstream source, with downstream mirrors treated as subordinate.
+- **Hermetic CI alignment:** The `validate` workflow change aligned GitHub Actions Node setup to `.nvmrc`, reducing environment-drift risk without changing workflow names or adding live dependencies.
+
+Execution patterns observed (descriptive):
+
+- The weekly slice is dominated by documentation-only governance work inside the `Class B Evidence Gathering` lane.
+- Supporting artifacts fell into three subordinate categories: review interpretation, repo-to-Notion reconciliation reporting, and strategy-memory capture.
+- One repo-infrastructure adjustment (`.github/workflows/validate.yml`) supported validation consistency rather than product capability expansion.
+
+What did not occur (absence statement; by explicit repo evidence):
+
+- No `apps/` or `packages/` product-surface changes were merged in this window.
+- No deposits/withdrawals/rails/custody execution flows were introduced.
+- No ADR acceptance-state changes, no required CI workflow name changes, and no live-network dependencies in CI are evidenced in this window's commit set.
+
+---
+
+## 7. Execution classification (A / B / C)
+
+Classification for this weekly slice (by merged evidence; non-authoritative):
+
+- All merged work in this window remains **Class A (informational / governance / reporting)**.
+
+Notes (scope boundary):
+
+- The EVID-B package series structures evidence requirements only; it does not approve evidence, activate pilot execution, or create Class B / C authority.
+- The `validate` workflow alignment is repo-infrastructure hygiene, not execution-layer expansion.
+
+---
+
+## 8. Capability progression (descriptive)
+
+Capabilities reinforced (by merged evidence):
+
+- **Class B evidence-lane breadth:** the repo now has documentation-only evidence shells spanning:
+  - customer eligibility
+  - KYC / AML responsibility
+  - custody provider / model
+  - rail / vendor permissioning
+  - settlement / finality
+  - stablecoin / conversion
+  - fee / FX / spread
+  - liquidity / withdrawal controls
+  - trust UX / disclosure
+  - Pilot Ops
+  - reconciliation
+- **Interpretive review maturity:** the weekly and MVP review artifacts continued the bounded review layer without converting it into sequencing authority.
+- **Repo authority mirroring discipline:** reconciliation reporting explicitly captures repo-to-Notion alignment as a governance maintenance function.
+- **CI environment consistency:** `validate` now reads the Node version from `.nvmrc`, aligning hosted validation with repo-declared tooling constraints.
+- **Institutional-memory capture:** `STRAT-001` preserved a strategy thesis as a non-authoritative reference artifact.
+
+Capabilities not advanced in this weekly slice (absence statement; by explicit repo evidence):
+
+- evidence gathering or evidence acceptance
+- execution-connected deposits
+- execution-connected withdrawals
+- custody implementation selection / operations
+- rail integration
+- automated routing or settlement
+- production trust-surface activation
+
+---
+
+## 9. Trust-surface coverage (descriptive)
+
+Trust surfaces strengthened (by merged evidence):
+
+- **Eligibility and compliance boundary honesty:** explicit evidence shells for customer eligibility and KYC / AML responsibility (`EVID-B-005`, `EVID-B-006`).
+- **Custody and rail posture clarity:** explicit evidence requirements for custody models, vendor permissioning, settlement/finality, and conversion dependencies (`EVID-B-007` through `EVID-B-010`).
+- **Pricing and liquidity transparency framing:** fee / FX / spread and liquidity / withdrawal control evidence requirements are now separated and named rather than implied (`EVID-B-011`, `EVID-B-012`).
+- **User-facing trust communication boundary:** trust UX / disclosure is framed as evidence requirements rather than approved product wording (`EVID-B-013`).
+- **Operational and accounting boundary visibility:** Pilot Ops and reconciliation are framed as evidence questions and source-of-truth concerns, not approved processes (`EVID-B-014`, `EVID-B-015`).
+- **Validation-environment trust:** Node-version alignment in `validate` reduces avoidable CI/tooling drift between local and hosted checks.
+
+Trust surfaces not covered (remaining gaps; absence statement, not a plan):
+
+- No evidence is shown as gathered, reviewed, accepted, or converted into ADR/governance approval in this window.
+- No operational proof exists here for custody, vendors, settlement, withdrawal reliability, support handling, or reconciliation correctness; the merged work remains scaffolding and reporting only.
+- No customer-facing trust copy, execution control, or runtime system behavior is approved or demonstrated by this weekly slice.
+
+---
+
+## 10. North Star verdict (non-authoritative)
+
+Verdict for this window (non-authoritative, based on merged evidence only):
+
+- Net-positive for trust-surface coverage and governance clarity: the repo materially widened the documented evidence frame for future Class B scrutiny while preserving deny-by-default language, subordinate reporting layers, and non-authorizing boundaries.
+
+This verdict does not imply Class B readiness, evidence sufficiency, operational approval, or implementation activation; it is a descriptive assessment of governance-layer coverage only.
+
+---
+
+## 11. Risks / notes
+
+- **Risk of coverage being misread as readiness:** A broad evidence-package set can be mistaken for completed diligence. The artifacts repeatedly guard against this, but the interpretive risk remains if readers ignore evidence-state labels and authority order.
+- **Unresolved ambiguity around non-ticket artifacts:** `STRAT-001`, the Notion reconciliation report, and review artifacts are merged and repo-native, but they are not completed execution tickets in `HEDGR_STATUS.md`. This review includes them as merged artifacts only, not as authority-bearing completion records.
+- **Scaffolding without gathered evidence:** The weekly slice improved question coverage more than factual closure; repo truth still shows question-framed / missing states across the evidence lane.
+- **No runtime corroboration:** Trust-surface language, controls, and reconciliation framing remain undocumented requirements rather than demonstrated system behavior in this window.
+
+---
+
+## 12. Optional non-authoritative evaluation criteria (for future weekly comparisons)
+
+These criteria are non-authoritative and are included only to keep weekly reviews comparable:
+
+- Did the merged slice reduce ambiguity about which trust surfaces are explicitly documented versus still implicit?
+- Did the merged slice preserve `docs/ops/HEDGR_STATUS.md` §7 / §7a as the sole activation surface with no sequencing by review or strategy artifacts?
+- Did any merged change introduce execution semantics, live-network dependencies in CI, or customer-money authority (should remain `no` unless repo authority explicitly widens scope)?

--- a/docs/ops/reviews/weekly/2026-06-06-weekly-review.md
+++ b/docs/ops/reviews/weekly/2026-06-06-weekly-review.md
@@ -1,0 +1,290 @@
+# 2026-06-06 Weekly Review
+
+## 1. Status / Authority / Scope / Last updated
+
+Status: Non-authoritative weekly review artifact; descriptive evidence only, not direction
+Authority: Subordinate to `docs/ops/HEDGR_STATUS.md`, `AGENTS.md`, accepted ADRs, and repo-native doctrine (`docs/doctrine/*`, `.cursorrules`)
+Scope: Repo-native, explicit merged-work evidence within the weekly time window ending on 2026-06-06; excludes in-progress or inferred work
+
+Weekly time window (end date = run date): 2026-05-31 through 2026-06-06 (inclusive; AWST)
+
+Execution mode: `READ_ONLY` (codex-synthesizer posture)
+Last updated: 2026-06-06
+
+This report does not name a next ticket, activate work, suggest sequencing, approve implementation, or alter `docs/ops/HEDGR_STATUS.md` §7 / §7a authority.
+
+Included merged-work evidence (explicit commits on `main` in this window):
+
+- `8bae9fa` — docs(ops): add May 29 review artifacts (#184)
+- `58a0b63` — docs(ops): add EVID-B-005 eligibility evidence package (#185)
+- `b0cb982` — docs(ops): add EVID-B-006 KYC AML evidence package (#186)
+- `2a13a78` — docs(ops): add Notion reconciliation report (#187)
+- `a527071` — docs(ops): add EVID-B-007 custody evidence package (#188)
+- `39eaec3` — docs(ops): add EVID-B-008 rail vendor evidence shell (#189)
+- `6ed6d17` — docs(ops): capture STRAT-001 treasury thesis (#190)
+- `40e09a8` — docs(ops): add EVID-B-009 settlement finality package (#191)
+- `621f275` — docs(ops): add stablecoin conversion evidence package (#192)
+- `3cc0989` — docs(ops): add EVID-B-011 evidence package (#193)
+- `84fee09` — docs(ops): add EVID-B-012 withdrawal evidence package (#194)
+- `3492cee` — docs(ops): add EVID-B-013 trust ux disclosure package (#195)
+- `4a7e0c9` — docs(ops): add Pilot Ops evidence package skeleton (#196)
+- `d34e62f` — docs(ops): add reconciliation evidence package (#197)
+
+Completed-ticket evidence included (only where completion is explicit in repo authority):
+
+- `EVID-B-005` (documentation-only) — Class B Customer Eligibility Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §78)
+- `EVID-B-006` (documentation-only) — Class B KYC / AML Responsibility Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §79)
+- `EVID-B-007` (documentation-only) — Class B Custody Provider / Model Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §80)
+- `EVID-B-008` (documentation-only) — Class B Rail / Vendor Permission Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §81)
+- `EVID-B-009` (documentation-only) — Class B Rail Settlement / Finality Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §82)
+- `EVID-B-010` (documentation-only) — Class B Stablecoin / Conversion Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §83)
+- `EVID-B-011` (documentation-only) — Class B Fee / FX / Spread Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §84)
+- `EVID-B-012` (documentation-only) — Class B Liquidity / Withdrawal Control Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §85)
+- `EVID-B-013` (documentation-only) — Class B Trust UX / Disclosure Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §86)
+- `EVID-B-014` (documentation-only) — Class B Pilot Ops Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §87)
+- `EVID-B-015` (documentation-only) — Class B Reconciliation Evidence Package Skeleton (completed record `docs/ops/HEDGR_STATUS.md` §88)
+
+Included merged artifacts without completed-ticket status in `HEDGR_STATUS.md`:
+
+- `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_009_TO_013.md`
+- `docs/ops/reviews/weekly/2026-05-29-weekly-review.md`
+- `docs/ops/reconciliation/NOTION_REPO_RECONCILIATION_REPORT_2026-06-01.md`
+- `docs/ops/strategy/STRAT-001-WHATSAPP-TREASURY-INTERFACE-THESIS.md`
+- `.github/workflows/validate.yml` (`node-version-file: '.nvmrc'` alignment)
+
+Excluded (by rule):
+
+- Any work not merged to the repo within the time window.
+- Any in-progress tickets not explicitly recorded as completed in `docs/ops/HEDGR_STATUS.md`.
+- Any external-only activity not mirrored by repo artifacts.
+- Any interpretation of `STRAT-001`, review artifacts, or reconciliation reporting as implementation approval, sequencing authority, or completed execution unless repo authority says so explicitly.
+
+---
+
+## 2. Purpose
+
+This weekly review summarises what the repo explicitly shows was merged within the time window ending 2026-06-06, and assesses (non-authoritatively) how that merged work reinforces Hedgr's MVP North Star and trust-surface posture without creating sequencing, activation, or approval authority.
+
+---
+
+## 3. Governing inputs used
+
+- `docs/ops/reviews/README.md` — review guardrails and required structure
+- `docs/ops/HEDGR_STATUS.md` — canonical merged-truth, posture, completed-ticket records, and the §7 / §7a sequencing authority constraint
+- `AGENTS.md` — repo execution posture and CI / hermetic constraints
+- `docs/doctrine/hedgr-whitepaper.md` — North Star framing (Stability Wallet thesis; Stability Engine as system center)
+- `docs/doctrine/hedgr-mvp-project-specification.md` — doctrine-grade MVP constraints, execution classes A/B/C, and trust boundaries
+- `docs/decisions/SPRINT-2-ADR-INDEX.md` — accepted ADR index and read-only / governance-boundary context
+- Prior weekly structure reference: `docs/ops/reviews/weekly/2026-06-05-weekly-review.md`
+- Repo log evidence for this window: `git log --since 2026-05-31 --until 2026-06-06` (commit subjects listed in §1)
+
+Repo-authoritative boundary facts used in this review:
+
+- `docs/ops/HEDGR_STATUS.md` §7 / §7a are the only sequencing / activation surfaces; this review does not introduce or imply sequencing.
+- Execution classes A/B/C are doctrine-defined and governance-gated; documentation, reconciliation, review, strategy-capture, and CI-alignment artifacts do not create Class B or Class C authority by themselves.
+
+If ambiguity exists between external narratives and repo truth, repo truth wins; this review surfaces ambiguity rather than resolving it by inference.
+
+---
+
+## 4. MVP North Star frame
+
+For this weekly review, the MVP North Star is compressed into the following evaluation criteria:
+
+1. Stability-first: reinforce preservation and calm trust before yield or growth.
+2. Liquidity integrity: treat withdrawal-path honesty, liquidity control, and settlement/reconciliation clarity as core trust surfaces without implying operational readiness.
+3. Governed phases: preserve the execution-class gating model (A informational / B manual-limited / C automated) without implying Class B/C readiness through governance artifacts alone.
+4. Non-misleading: do not imply legal clearance, vendor approval, accounting truth, ledger truth, fund movement, or autonomous execution unless explicitly authorized.
+5. Engine-centered and subordinate layers: preserve Stability Engine centering while keeping review, strategy, and Copilot-adjacent artifacts subordinate to repo authority.
+
+---
+
+## 5. Time-based summary (repo-native evidence only)
+
+### 2026-06-01 — Review cadence continued; CI Node version alignment recorded; customer eligibility and KYC / AML evidence shells added
+
+What changed (repo evidence):
+
+- Added review artifacts:
+  - `docs/ops/reviews/weekly/2026-05-29-weekly-review.md`
+  - `docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_009_TO_013.md`
+- Updated `.github/workflows/validate.yml` to use `node-version-file: '.nvmrc'` instead of a hard-coded Node version.
+- Added the Customer Eligibility Evidence Package skeleton and recorded `EVID-B-005` in `docs/ops/HEDGR_STATUS.md`.
+- Added the KYC / AML Responsibility Evidence Package skeleton and recorded `EVID-B-006` in `docs/ops/HEDGR_STATUS.md`.
+- Added `docs/ops/reconciliation/NOTION_REPO_RECONCILIATION_REPORT_2026-06-01.md`.
+
+Meaning (non-authoritative interpretation):
+
+- Review cadence and repo-to-Notion reconciliation evidence continued as interpretive / reporting layers without widening execution authority.
+- CI guardrail posture improved by aligning `validate` with the repo-pinned Node version source of truth.
+- The Class B evidence lane expanded from legal/jurisdiction framing into participant eligibility and KYC / AML responsibility questions while preserving missing/question-framed evidence states rather than implying answers.
+
+### 2026-06-02 — Custody, rail/vendor, settlement/finality, stablecoin/conversion, fee/FX/spread, and strategy-memory artifacts expanded the evidence frame
+
+What changed (repo evidence):
+
+- Added and recorded completed documentation-only evidence package skeletons:
+  - `EVID-B-007` — custody provider / model
+  - `EVID-B-008` — rail / vendor permission
+  - `EVID-B-009` — rail settlement / finality
+  - `EVID-B-010` — stablecoin / conversion
+  - `EVID-B-011` — fee / FX / spread
+- Added `docs/ops/strategy/STRAT-001-WHATSAPP-TREASURY-INTERFACE-THESIS.md` as thesis capture / institutional memory.
+
+Meaning (non-authoritative interpretation):
+
+- The repo widened evidence coverage across the main operational trust surfaces required before any future Class B consideration: custody, vendor permissions, settlement finality, conversion pathways, and pricing/fee clarity.
+- `STRAT-001` preserved an exploratory thesis as institutional memory only; the artifact remains explicitly subordinate and does not function as execution authority or ticket activation.
+
+### 2026-06-03 — Liquidity/withdrawal, trust UX/disclosure, and Pilot Ops evidence shells extended the Class B evidence lane
+
+What changed (repo evidence):
+
+- Added and recorded completed documentation-only evidence package skeletons:
+  - `EVID-B-012` — liquidity / withdrawal control
+  - `EVID-B-013` — trust UX / disclosure
+  - `EVID-B-014` — Pilot Ops
+
+Meaning (non-authoritative interpretation):
+
+- The evidence lane moved beyond legal/vendor/custody questions into user-facing trust communication and pilot-operations dependencies.
+- The merged artifacts continued to frame unresolved operational questions explicitly while preserving negative-authority language: no approvals, no evidence acceptance, no Class B readiness, and no customer-money authority.
+
+### 2026-06-04 — Reconciliation evidence shell completed the current documented evidence-package sweep
+
+What changed (repo evidence):
+
+- Added and recorded `EVID-B-015` — Reconciliation Evidence Package Skeleton.
+- Updated the Class B Evidence Registry to reference the reconciliation package while preserving package state as question-framed / missing.
+
+Meaning (non-authoritative interpretation):
+
+- The repo now contains explicit documentation-only evidence shells across eligibility, compliance responsibility, custody, vendor permissioning, settlement/finality, stablecoin conversion, fee/FX/spread, liquidity/withdrawal control, trust disclosures, pilot operations, and reconciliation.
+- This is evidence-lane coverage expansion, not evidence acceptance or operational readiness.
+
+### 2026-06-05 through 2026-06-06 — No additional merged work visible in repo history for this bounded window tail
+
+What changed (repo evidence):
+
+- `git log --merges --since='2026-06-05 00:00' --until='2026-06-06 23:59'` returned no merge commits.
+
+Meaning (non-authoritative interpretation):
+
+- The bounded weekly window ends without additional merged repo-native evidence beyond the documentation and governance sweep already visible through `d34e62f`.
+- This absence is included to keep the time window explicit; it does not imply inactivity outside the repo or outside merged state.
+
+---
+
+## 6. Process assessment
+
+What held well (descriptive):
+
+- **Authority hygiene:** The merged EVID-B artifacts repeatedly deny approval, readiness, evidence acceptance, and successor-ticket creation, preserving `docs/ops/HEDGR_STATUS.md` §7 / §7a as the only activation surface.
+- **Coverage discipline:** The evidence lane expanded in a structured progression across operational trust surfaces without silently switching from scaffolding to conclusions.
+- **Repo-first reconciliation posture:** The Notion reconciliation report and `HEDGR_STATUS.md` updates reinforce repo authority as the upstream source, with downstream mirrors treated as subordinate.
+- **Hermetic CI alignment:** The `validate` workflow change aligned GitHub Actions Node setup to `.nvmrc`, reducing environment-drift risk without changing workflow names or adding live dependencies.
+
+Execution patterns observed (descriptive):
+
+- The weekly slice is dominated by documentation-only governance work inside the `Class B Evidence Gathering` lane.
+- Supporting artifacts fell into three subordinate categories: review interpretation, repo-to-Notion reconciliation reporting, and strategy-memory capture.
+- One repo-infrastructure adjustment (`.github/workflows/validate.yml`) supported validation consistency rather than product capability expansion.
+
+What did not occur (absence statement; by explicit repo evidence):
+
+- No `apps/` or `packages/` product-surface changes were merged in this window.
+- No deposits/withdrawals/rails/custody execution flows were introduced.
+- No ADR acceptance-state changes, no required CI workflow name changes, and no live-network dependencies in CI are evidenced in this window's commit set.
+
+---
+
+## 7. Execution classification (A / B / C)
+
+Classification for this weekly slice (by merged evidence; non-authoritative):
+
+- All merged work in this window remains **Class A (informational / governance / reporting)**.
+
+Notes (scope boundary):
+
+- The EVID-B package series structures evidence requirements only; it does not approve evidence, activate pilot execution, or create Class B / C authority.
+- The `validate` workflow alignment is repo-infrastructure hygiene, not execution-layer expansion.
+
+---
+
+## 8. Capability progression (descriptive)
+
+Capabilities reinforced (by merged evidence):
+
+- **Class B evidence-lane breadth:** the repo now has documentation-only evidence shells spanning:
+  - customer eligibility
+  - KYC / AML responsibility
+  - custody provider / model
+  - rail / vendor permissioning
+  - settlement / finality
+  - stablecoin / conversion
+  - fee / FX / spread
+  - liquidity / withdrawal controls
+  - trust UX / disclosure
+  - Pilot Ops
+  - reconciliation
+- **Interpretive review maturity:** the weekly and MVP review artifacts continued the bounded review layer without converting it into sequencing authority.
+- **Repo authority mirroring discipline:** reconciliation reporting explicitly captures repo-to-Notion alignment as a governance maintenance function.
+- **CI environment consistency:** `validate` now reads the Node version from `.nvmrc`, aligning hosted validation with repo-declared tooling constraints.
+- **Institutional-memory capture:** `STRAT-001` preserved a strategy thesis as a non-authoritative reference artifact.
+
+Capabilities not advanced in this weekly slice (absence statement; by explicit repo evidence):
+
+- evidence gathering or evidence acceptance
+- execution-connected deposits
+- execution-connected withdrawals
+- custody implementation selection / operations
+- rail integration
+- automated routing or settlement
+- production trust-surface activation
+
+---
+
+## 9. Trust-surface coverage (descriptive)
+
+Trust surfaces strengthened (by merged evidence):
+
+- **Eligibility and compliance boundary honesty:** explicit evidence shells for customer eligibility and KYC / AML responsibility (`EVID-B-005`, `EVID-B-006`).
+- **Custody and rail posture clarity:** explicit evidence requirements for custody models, vendor permissioning, settlement/finality, and conversion dependencies (`EVID-B-007` through `EVID-B-010`).
+- **Pricing and liquidity transparency framing:** fee / FX / spread and liquidity / withdrawal control evidence requirements are now separated and named rather than implied (`EVID-B-011`, `EVID-B-012`).
+- **User-facing trust communication boundary:** trust UX / disclosure is framed as evidence requirements rather than approved product wording (`EVID-B-013`).
+- **Operational and accounting boundary visibility:** Pilot Ops and reconciliation are framed as evidence questions and source-of-truth concerns, not approved processes (`EVID-B-014`, `EVID-B-015`).
+- **Validation-environment trust:** Node-version alignment in `validate` reduces avoidable CI/tooling drift between local and hosted checks.
+
+Trust surfaces not covered (remaining gaps; absence statement, not a plan):
+
+- No evidence is shown as gathered, reviewed, accepted, or converted into ADR/governance approval in this window.
+- No operational proof exists here for custody, vendors, settlement, withdrawal reliability, support handling, or reconciliation correctness; the merged work remains scaffolding and reporting only.
+- No customer-facing trust copy, execution control, or runtime system behavior is approved or demonstrated by this weekly slice.
+
+---
+
+## 10. North Star verdict (non-authoritative)
+
+Verdict for this window (non-authoritative, based on merged evidence only):
+
+- Net-positive for trust-surface coverage and governance clarity: the repo materially widened the documented evidence frame for future Class B scrutiny while preserving deny-by-default language, subordinate reporting layers, and non-authorizing boundaries.
+- No evidence in this window shows a shift from governance scaffolding into execution authority, operating readiness, or customer-money posture.
+
+---
+
+## 11. Risks / notes
+
+- **Cadence overlap note:** Because the previous weekly review was created on 2026-06-05, this weekly window substantially overlaps the prior one; this report remains valid because it is bounded by the requested run date and uses repo-native merged evidence only.
+- **Unresolved ambiguity:** The repository shows completed documentation-only evidence package skeletons, but does not show evidence acceptance, evidence completeness, or downstream authority changes; this review therefore treats those packages strictly as scaffolding.
+- **Scope boundary note:** `STRAT-001`, review artifacts, and reconciliation reporting are included only as merged artifacts within the window; they are not treated as implementation completion, sequencing authority, or release readiness.
+
+---
+
+## 12. Non-authoritative evaluation criteria (optional)
+
+These criteria are non-authoritative and are included only to keep weekly reviews comparable:
+
+- Did merged work increase explicit trust-surface coverage without overstating capability?
+- Did the repo preserve execution-class discipline and avoid accidental authority creation?
+- Did the weekly slice improve clarity around operational boundaries, dependencies, or governance traceability?
+- Did any merged artifact create evidence of real execution capability, or did it remain informational only?


### PR DESCRIPTION
## Summary
Adds bounded review documentation under docs/ops/reviews: the GOV-B-014 to GOV-B-016 MVP process review already on this branch, plus the GOV-B-017 to EVID-B-004 MVP process review and 2026-06-05 / 2026-06-06 weekly reviews.

## Scope
**In**
- docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_014_TO_016.md
- docs/ops/reviews/MVP/HEDGR_MVP_PROCESS_REVIEW_GOV_B_017_TO_EVID_B_004.md
- docs/ops/reviews/weekly/2026-06-05-weekly-review.md
- docs/ops/reviews/weekly/2026-06-06-weekly-review.md

**Out**
- Runtime code, tests, workflows, backend, frontend, packages, ADR status changes, implementation authority, sequencing authority, custody, rails, deposits, withdrawals, ledger, treasury, Copilot execution, Class C automation, and customer fund movement authority.

## Acceptance Criteria
- [x] Given repo-native review artifacts are ready, when published, then they remain descriptive / non-authoritative and subordinate to docs/ops/HEDGR_STATUS.md.
- [x] Given this is docs-only governance work, when reviewed, then no runtime or money-path behavior is changed.

## Risk / Impact
- Area: area:docs
- Risk: risk:low
- Money-path impact: none
- Trust / policy impact: none; review artifacts preserve non-authorizing language.

## Local Validation
- [x] git diff --check -- docs/ops/reviews/MVP docs/ops/reviews/weekly
- [x] pnpm run validate
- [x] NEXT_PUBLIC_AUTH_MODE=mock NEXT_PUBLIC_DEFI_MODE=mock NEXT_PUBLIC_FX_MODE=stub NEXT_PUBLIC_MARKET_MODE=manual NEXT_PUBLIC_MARKET_SELECTED=UNKNOWN NEXT_PUBLIC_APP_ENV=dev NEXT_PUBLIC_API_BASE_URL=http://localhost:5050 NEXT_PUBLIC_FEATURE_COPILOT_ENABLED=true pnpm --filter @hedgr/frontend run e2e:ci

## Required Checks
- validate
- E2E smoke (@hedgr/frontend)

## Flags / Env Changes
None.

## Rollback
Single revert commit. No migrations, secrets, runtime flags, or data changes.

## Reviewer Guidance
Start with docs/ops/reviews/MVP and docs/ops/reviews/weekly. Focus on authority boundaries, included/excluded evidence, and whether review language stays descriptive rather than authorizing.